### PR TITLE
Update swap venue naming for new contract

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -48,12 +48,7 @@ export const SWAP_VENUES: Record<string, SwapVenueConfig> = {
     name: "Astroport",
     imageURL: "https://avatars.githubusercontent.com/u/87135340",
   },
-  "osmosis-xcs": {
-    name: "Osmosis",
-    imageURL:
-      "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/osmosis/dappImg/app.png",
-  },
-  "osmosis-sq": {
+  "osmosis-poolmanager": {
     name: "Osmosis",
     imageURL:
       "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/osmosis/dappImg/app.png",


### PR DESCRIPTION
This PR changes the swap venue name to use the new contract, not to be merged until server has pushed all the changes to prod