### PR TITLE
[ENG-1462]Convert API URL to environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+First, ensure you have a `.env.development.local` file with the following environment variables:
+
+* `NEXT_PUBLIC_API_URL`: Root URL of the Skip API server the frontend will query. The two acceptable values are: 
+    * `https://api.skip.money/v1`: The stable, production API server
+    * `https://solve-dev.skip.money/v1`: The nightly, unstable dev server used for testing and previewing new functionality
+(An example has been included in the repo under example.env). You *MUST* copy this to `env.development.local`. Internally, we use `env.development.local` to develop against the nightly API and `env.production.local` to develop against the stable one. 
+
+## Develop
+
+Run the development server:
 
 ```bash
 npm run dev
@@ -17,6 +26,16 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+
+## Build and Run
+
+```bash
+npm run build && npm run start
+# or
+yarn build && yarn start
+# or 
+pnpm build && pnpm start
+```
 
 ## Learn More
 

--- a/example.env
+++ b/example.env
@@ -1,0 +1,5 @@
+# production api
+NEXT_PUBLIC_API_URL=https://api.skip.money/v1
+
+# development API
+# NEXT_PUBLIC_API_URL=https://solve-dev.skip.money/v1

--- a/src/solve/api.ts
+++ b/src/solve/api.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
 import { Affiliate, Chain, MultiChainMsg, Operation, SwapVenue } from "./types";
 
-const API_URL = "https://api.skip.money/v1";
-
+const API_URL = `${process.env.NEXT_PUBLIC_API_URL}`;
 interface GetChainsResponse {
   chains: Chain[];
 }


### PR DESCRIPTION
This changes converts the API_URL to an environment variable.

This allows Next JS to set the API URL through environment variables in Vercel -- allowing us to have two different deployments simulataneously:

* A production deployment that depends on the production API
* A dev deployment that depends on the dev API

The new deployment flow will be: 
1. **Open PRs targeting the `staging` branch**: PRs opened _from_ any branch other than `staging` will preview using the dev APIs. (https://solve-dev.skip.money)
2. **Staging will deploy to staging.ibc.fun using production APIs**: After the PR is merged, the staging branch update the deployment at staging.skip.money -- which will always use the production APIs. 
3. Open a PR from staging into main to update ibc.fun