### PR TITLE
Display name of origin chain when assets with same symbol exist

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -66,7 +66,7 @@ export default function Home() {
   }, 5000);
 
   return (
-    <div className="bg-white max-w-lg mx-auto shadow-xl rounded-3xl p-6 py-6 relative">
+    <div className="bg-white max-w-xl mx-auto shadow-xl rounded-3xl p-6 py-6 relative">
       <div className="space-y-6">
         <div>
           <p className="font-semibold text-2xl">From</p>


### PR DESCRIPTION
When assets with duplicate symbols exist (Noble USDC, Gravity Bridge USDC), display origin name to differentiate them.

<img width="623" alt="Screenshot 2023-08-21 at 6 00 17 AM" src="https://github.com/skip-mev/ibc-dot-fun/assets/91888455/e922a682-2a49-4793-806c-07f8dfa3604e">
<img width="583" alt="Screenshot 2023-08-21 at 6 00 24 AM" src="https://github.com/skip-mev/ibc-dot-fun/assets/91888455/1d44441a-a620-4283-9394-a84fa743f21c">
<img width="639" alt="Screenshot 2023-08-21 at 6 03 40 AM" src="https://github.com/skip-mev/ibc-dot-fun/assets/91888455/415209ab-1073-49f1-a85d-db94883e0211">
