### PR TITLE
[ENG-1696] Find equivalent destination token when destination chain changes

### DIFF
--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -7,6 +7,7 @@ import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import { useChain } from "@cosmos-kit/react";
 import { WalletStatus } from "@cosmos-kit/core";
 import TransactionDialog from "../TransactionDialog";
+import { on } from "events";
 
 const RouteLoading = () => (
   <div className="bg-black text-white/50 font-medium uppercase text-xs p-3 rounded-md flex items-center w-full text-left">
@@ -67,6 +68,10 @@ export const SwapWidget: FC = () => {
     numberOfTransactions,
     route,
     insufficientBalance,
+    onSourceChainChange,
+    onSourceAssetChange,
+    onDestinationChainChange,
+    onDestinationAssetChange,
   } = useSwapWidget();
 
   const {
@@ -91,21 +96,9 @@ export const SwapWidget: FC = () => {
               })
             }
             asset={sourceAsset}
-            onAssetChange={(asset) => {
-              setFormValues({
-                ...formValues,
-                sourceAsset: asset,
-              });
-            }}
+            onAssetChange={onSourceAssetChange}
             chain={sourceChain}
-            onChainChange={(chain) =>
-              setFormValues({
-                ...formValues,
-                sourceChain: chain,
-                sourceAsset: undefined,
-                amountIn: "",
-              })
-            }
+            onChainChange={onSourceChainChange}
             showBalance
             chains={chains}
           />
@@ -135,20 +128,9 @@ export const SwapWidget: FC = () => {
           <AssetInput
             amount={amountOut}
             asset={destinationAsset}
-            onAssetChange={(asset) => {
-              setFormValues({
-                ...formValues,
-                destinationAsset: asset,
-              });
-            }}
+            onAssetChange={onDestinationAssetChange}
             chain={destinationChain}
-            onChainChange={(chain) =>
-              setFormValues({
-                ...formValues,
-                destinationChain: chain,
-                destinationAsset: undefined,
-              })
-            }
+            onChainChange={onDestinationChainChange}
             chains={chains}
           />
         </div>

--- a/src/components/__tests__/SwapWidget.test.tsx
+++ b/src/components/__tests__/SwapWidget.test.tsx
@@ -246,12 +246,27 @@ describe("SwapWidget", () => {
 
     // Select destination asset
     fireEvent.click(destinationAssetButton);
-    fireEvent.click(await within(destinationAssetSection).findByText("CMDX"));
+    fireEvent.click(await within(destinationAssetSection).findByText("ATOM"));
 
-    // Destination chain is now Comdex
+    // Destination chain is now Cosmos Hub
     await waitFor(() =>
-      expect(destinationChainButton).toHaveTextContent("Comdex")
+      expect(destinationChainButton).toHaveTextContent("Cosmos Hub")
     );
+
+    // Destination asset is now ATOM
+    await waitFor(() => within(destinationAssetSection).findByText("ATOM"));
+
+    // Select new destination chain
+    fireEvent.click(destinationChainButton);
+    fireEvent.click(
+      await within(destinationAssetSection).findByText("Osmosis")
+    );
+
+    // Destination chain is now Osmosis
+    expect(destinationChainButton).toHaveTextContent("Osmosis");
+
+    // Destination asset should still be ATOM
+    await waitFor(() => within(destinationAssetSection).findByText("ATOM"));
   });
 
   it("can swap source and destination", async () => {


### PR DESCRIPTION
If user selects a destination token, then changes the destination chain, attempt to find equivalent token on new source chain.

Also moves the form state update logic to the `useFormValues` hook