### PR TITLE
Handle missing assets in route display

### DIFF
--- a/src/components/RouteDisplay.tsx
+++ b/src/components/RouteDisplay.tsx
@@ -47,8 +47,6 @@ const RouteEnd: FC<{
 };
 
 const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
-  console.log(action);
-
   const { chains } = useChains();
 
   const sourceChain = chains.find(

--- a/src/components/RouteDisplay.tsx
+++ b/src/components/RouteDisplay.tsx
@@ -47,14 +47,16 @@ const RouteEnd: FC<{
 };
 
 const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
+  console.log(action);
+
   const { chains } = useChains();
 
   const sourceChain = chains.find(
-    (c) => c.chainID === action.sourceChain
+    (c) => c.chainID === action.sourceChain,
   ) as Chain;
 
   const destinationChain = chains.find(
-    (c) => c.chainID === action.destinationChain
+    (c) => c.chainID === action.destinationChain,
   ) as Chain;
 
   const { getAsset } = useAssets();
@@ -62,8 +64,28 @@ const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
   const asset = getAsset(action.asset, sourceChain.chainID);
 
   if (!asset) {
-    console.log(action);
-    return null;
+    return (
+      <div className="flex items-center gap-2">
+        <div className="w-14 h-14 flex items-center justify-center">
+          <div className="w-2 h-2 bg-neutral-200 rounded-full" />
+        </div>
+        <div>
+          <p className="text-sm text-neutral-500">
+            Transfer to{" "}
+            <img
+              className="inline-block w-4 h-4 -mt-1"
+              src={`${chainNameToChainlistURL(
+                destinationChain.chainName,
+              )}/chainImg/_chainImg.svg`}
+              alt=""
+            />{" "}
+            <span className="font-semibold text-black">
+              {destinationChain.prettyName}
+            </span>
+          </p>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -83,7 +105,7 @@ const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
           <img
             className="inline-block w-4 h-4 -mt-1"
             src={`${chainNameToChainlistURL(
-              sourceChain.chainName
+              sourceChain.chainName,
             )}/chainImg/_chainImg.svg`}
             alt=""
           />{" "}
@@ -94,7 +116,7 @@ const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
           <img
             className="inline-block w-4 h-4 -mt-1"
             src={`${chainNameToChainlistURL(
-              destinationChain.chainName
+              destinationChain.chainName,
             )}/chainImg/_chainImg.svg`}
             alt=""
           />{" "}
@@ -119,6 +141,62 @@ const SwapStep: FC<{ action: SwapAction }> = ({ action }) => {
   const assetOut = getAsset(action.destinationAsset, chain.chainID);
 
   const venue = SWAP_VENUES[action.venue];
+
+  if (!assetIn && assetOut) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="w-14 h-14 flex items-center justify-center">
+          <div className="w-2 h-2 bg-neutral-200 rounded-full" />
+        </div>
+        <div>
+          <p className="text-sm text-neutral-500">
+            Swap to{" "}
+            <img
+              className="inline-block w-4 h-4 -mt-1"
+              src={assetOut.logoURI}
+              alt=""
+            />{" "}
+            <span className="font-semibold text-black">{assetOut.symbol}</span>{" "}
+            on{" "}
+            <img
+              className="inline-block w-4 h-4 -mt-1"
+              src={venue.imageURL}
+              alt=""
+            />{" "}
+            <span className="font-semibold text-black">{venue.name}</span>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (assetIn && !assetOut) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="w-14 h-14 flex items-center justify-center">
+          <div className="w-2 h-2 bg-neutral-200 rounded-full" />
+        </div>
+        <div>
+          <p className="text-sm text-neutral-500">
+            Swap{" "}
+            <img
+              className="inline-block w-4 h-4 -mt-1"
+              src={assetIn.logoURI}
+              alt=""
+            />{" "}
+            <span className="font-semibold text-black">{assetIn.symbol}</span>{" "}
+            on{" "}
+            <img
+              className="inline-block w-4 h-4 -mt-1"
+              src={venue.imageURL}
+              alt=""
+            />{" "}
+            <span className="font-semibold text-black">{venue.name}</span>
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (!assetIn || !assetOut) {
     return null;
@@ -168,20 +246,20 @@ const RouteDisplay: FC<Props> = ({ route }) => {
 
   const sourceAsset = getAsset(
     route.sourceAssetDenom,
-    route.sourceAssetChainID
+    route.sourceAssetChainID,
   );
 
   const destinationAsset = getAsset(
     route.destAssetDenom,
-    route.destAssetChainID
+    route.destAssetChainID,
   );
 
   const sourceChain = chains.find(
-    (c) => c.chainID === route.sourceAssetChainID
+    (c) => c.chainID === route.sourceAssetChainID,
   ) as Chain;
 
   const destinationChain = chains.find(
-    (c) => c.chainID === route.destAssetChainID
+    (c) => c.chainID === route.destAssetChainID,
   ) as Chain;
 
   const amountIn = useMemo(() => {
@@ -196,7 +274,7 @@ const RouteDisplay: FC<Props> = ({ route }) => {
     try {
       return ethers.formatUnits(
         route.estimatedAmountOut ?? 0,
-        destinationAsset?.decimals ?? 6
+        destinationAsset?.decimals ?? 6,
       );
     } catch {
       return "0.0";

--- a/src/context/assets.tsx
+++ b/src/context/assets.tsx
@@ -34,7 +34,7 @@ export const AssetsContext = createContext<AssetsContext>({
 function getAssetSymbol(
   asset: AssetWithMetadata,
   assets: Asset[],
-  chains: Chain[]
+  chains: Chain[],
 ) {
   const hasDuplicates =
     (assets?.filter((a) => a.symbol === asset.symbol).length ?? 0) > 1;
@@ -59,15 +59,18 @@ export const AssetsProvider: FC<PropsWithChildren> = ({ children }) => {
       return {};
     }
 
-    return Object.entries(solveAssets).reduce((acc, [chainID, assets]) => {
-      return {
-        ...acc,
-        [chainID]: filterAssetsWithMetadata(assets).map((asset) => ({
-          ...asset,
-          symbol: getAssetSymbol(asset, assets, chains),
-        })),
-      };
-    }, {} as Record<string, AssetWithMetadata[]>);
+    return Object.entries(solveAssets).reduce(
+      (acc, [chainID, assets]) => {
+        return {
+          ...acc,
+          [chainID]: filterAssetsWithMetadata(assets).map((asset) => ({
+            ...asset,
+            symbol: getAssetSymbol(asset, assets, chains),
+          })),
+        };
+      },
+      {} as Record<string, AssetWithMetadata[]>,
+    );
   }, [chains, solveAssets]);
 
   function assetsByChainID(chainID: string) {
@@ -76,6 +79,10 @@ export const AssetsProvider: FC<PropsWithChildren> = ({ children }) => {
 
   function getAsset(denom: string, chainID: string) {
     const asset = assets[chainID]?.find((asset) => asset.denom === denom);
+
+    if (!asset) {
+      //
+    }
 
     return asset;
   }

--- a/src/context/assets.tsx
+++ b/src/context/assets.tsx
@@ -80,10 +80,6 @@ export const AssetsProvider: FC<PropsWithChildren> = ({ children }) => {
   function getAsset(denom: string, chainID: string) {
     const asset = assets[chainID]?.find((asset) => asset.denom === denom);
 
-    if (!asset) {
-      //
-    }
-
     return asset;
   }
 


### PR DESCRIPTION
Previously when an asset could not be found in the `RouteDisplay` components, it would not show that step. Now this is handled a little more intelligently.

<img width="501" alt="Screenshot 2023-09-21 at 6 26 16 AM" src="https://github.com/skip-mev/ibc-dot-fun/assets/91888455/5ee7d0a7-8e11-4000-b584-d8add2d25d91">
<img width="499" alt="Screenshot 2023-09-21 at 6 26 04 AM" src="https://github.com/skip-mev/ibc-dot-fun/assets/91888455/fa689ef7-874c-4a36-bd33-7a6e7dd655e5">
