### PR TITLE
feat: rewrite chain registry codegen script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,9 +105,9 @@
       "dev": true
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
-      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -205,23 +205,6 @@
         "string-similarity-js": "^2.1.4",
         "uuid": "^8.3.2",
         "ws": "^8.13.0"
-      }
-    },
-    "node_modules/@axelar-network/axelarjs-sdk/node_modules/@cosmjs/json-rpc": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.1.tgz",
-      "integrity": "sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.30.1",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@axelar-network/axelarjs-sdk/node_modules/@cosmjs/json-rpc/node_modules/@cosmjs/stream": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.1.tgz",
-      "integrity": "sha512-Fg0pWz1zXQdoxQZpdHRMGvUH5RqS6tPv+j9Eh7Q953UjMlrwZVo0YFLC8OTf/HKVf10E4i0u6aM8D69Q6cNkgQ==",
-      "dependencies": {
-        "xstream": "^11.14.0"
       }
     },
     "node_modules/@axelar-network/axelarjs-sdk/node_modules/@cosmjs/stargate": {
@@ -884,15 +867,20 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.5",
@@ -966,20 +954,27 @@
       }
     },
     "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.0.0-20230719110346-aa25660f4ff7.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.0.0-20230719110346-aa25660f4ff7.1.tgz",
+      "version": "1.0.0-20230316080531-954f7b05f384.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.0.0-20230316080531-954f7b05f384.1.tgz",
       "dependencies": {
         "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20230509103710-5e5b9fdd0180.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20230502210827-cc916c318597.1"
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221214150216-75b4300737fb.1"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.0.0"
       }
     },
+    "node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
+      "version": "1.0.0-20221214150216-75b4300737fb.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20221214150216-75b4300737fb.1.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.0.0"
+      }
+    },
     "node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
-      "version": "1.0.0-20230509103710-5e5b9fdd0180.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.0.0-20230509103710-5e5b9fdd0180.1.tgz",
+      "version": "1.0.0-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.0.0-20221020125208-34d970b699f8.1.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.0.0"
       }
@@ -994,39 +989,6 @@
         "@buf/cosmos_ics23.bufbuild_es": "1.0.0-20221207100654-55085f7c710a.1",
         "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20220908150232-8d7204855ec1.1"
       },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
-      }
-    },
-    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.0.0-20230316080531-954f7b05f384.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.0.0-20230316080531-954f7b05f384.1.tgz",
-      "dependencies": {
-        "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221214150216-75b4300737fb.1"
-      },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
-      }
-    },
-    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_cosmos-sdk.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20221214150216-75b4300737fb.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20221214150216-75b4300737fb.1.tgz",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
-      }
-    },
-    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/cosmos_gogo-proto.bufbuild_es": {
-      "version": "1.0.0-20221020125208-34d970b699f8.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.0.0-20221020125208-34d970b699f8.1.tgz",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.0.0"
-      }
-    },
-    "node_modules/@buf/cosmos_ibc.bufbuild_es/node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20220908150232-8d7204855ec1.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20220908150232-8d7204855ec1.1.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.0.0"
       }
@@ -1085,8 +1047,8 @@
       }
     },
     "node_modules/@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20230502210827-cc916c318597.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20230502210827-cc916c318597.1.tgz",
+      "version": "1.0.0-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20220908150232-8d7204855ec1.1.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.0.0"
       }
@@ -1135,87 +1097,6 @@
         "@babel/runtime": "^7.19.4"
       }
     },
-    "node_modules/@chain-registry/keplr/node_modules/@keplr-wallet/common": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.16.tgz",
-      "integrity": "sha512-RTbfe8LkPzQQqYntx53dZTuDUgx+W6KRY4g3fIv1c59DS/bp9ZqjYfUDmj3yH0GQk822zqJJwCtjk+qsgvyebg==",
-      "dependencies": {
-        "@keplr-wallet/crypto": "0.11.16",
-        "buffer": "^6.0.3",
-        "delay": "^4.4.0"
-      }
-    },
-    "node_modules/@chain-registry/keplr/node_modules/@keplr-wallet/cosmos": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.11.16.tgz",
-      "integrity": "sha512-Rgch9zw+GKQ2wAKw6I5+J8AAlKHs4MhnkGFfTuqy0e453Ig0+KCHvs+IgMURM9j6E7K0OPQVc4vCvWnQLs6Zbw==",
-      "dependencies": {
-        "@ethersproject/address": "^5.6.0",
-        "@keplr-wallet/common": "0.11.16",
-        "@keplr-wallet/crypto": "0.11.16",
-        "@keplr-wallet/proto-types": "0.11.16",
-        "@keplr-wallet/types": "0.11.16",
-        "@keplr-wallet/unit": "0.11.16",
-        "axios": "^0.27.2",
-        "bech32": "^1.1.4",
-        "buffer": "^6.0.3",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
-      }
-    },
-    "node_modules/@chain-registry/keplr/node_modules/@keplr-wallet/crypto": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.16.tgz",
-      "integrity": "sha512-th3t05Aq+uQLbhhiqIHbevY3pA4dBKr+vKcUpfdshcc78fI1eGpmzGcQKxlvbectBn4UwamTEANssyplXOGQqg==",
-      "dependencies": {
-        "@ethersproject/keccak256": "^5.5.0",
-        "bip32": "^2.0.6",
-        "bip39": "^3.0.3",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "crypto-js": "^4.0.0",
-        "elliptic": "^6.5.3",
-        "sha.js": "^2.4.11"
-      }
-    },
-    "node_modules/@chain-registry/keplr/node_modules/@keplr-wallet/proto-types": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.11.16.tgz",
-      "integrity": "sha512-0tX7AN1bmlZdpUwqgjQU6MI+p+qBBaWUxHvOrNYtvX0FShw9RihasWdrV6biciQewVd54fChVIGmYKhCLtwPsg==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
-      }
-    },
-    "node_modules/@chain-registry/keplr/node_modules/@keplr-wallet/types": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.16.tgz",
-      "integrity": "sha512-jkBWj6bcw6BZqPavLms3EcaK6YG4suoTPA9PuO6+eFjj7TomUrzzYdhXyc7Mm0K/KVEz5CjPxjmx7LsPuWYKgg==",
-      "dependencies": {
-        "axios": "^0.27.2",
-        "long": "^4.0.0",
-        "secretjs": "0.17.7"
-      }
-    },
-    "node_modules/@chain-registry/keplr/node_modules/@keplr-wallet/unit": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.11.16.tgz",
-      "integrity": "sha512-RRVE3oLZq84P4CQONHXDRX+jdqsP9Zar0V9ROAkG4qzitG2glNY/KCVd9SeSOatbGOb/4X88/4pH273TkjtlRA==",
-      "dependencies": {
-        "@keplr-wallet/types": "0.11.16",
-        "big-integer": "^1.6.48",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@chain-registry/keplr/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/@chain-registry/types": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@chain-registry/types/-/types-0.13.0.tgz",
@@ -1224,71 +1105,6 @@
         "@babel/runtime": "^7.19.4",
         "@keplr-wallet/cosmos": "^0.11.12",
         "@keplr-wallet/crypto": "^0.11.12"
-      }
-    },
-    "node_modules/@chain-registry/types/node_modules/@keplr-wallet/common": {
-      "version": "0.11.64",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.64.tgz",
-      "integrity": "sha512-kEnv6K+TxH+BBwwqUgiTcIXuRLBn6PaZMO4jwJbE1O8C8Qh/2j1QtkMLAMgl3Nj9qQkHgJ/dvA5oIqOIdLVMwg==",
-      "dependencies": {
-        "@keplr-wallet/crypto": "0.11.64",
-        "buffer": "^6.0.3",
-        "delay": "^4.4.0"
-      }
-    },
-    "node_modules/@chain-registry/types/node_modules/@keplr-wallet/cosmos": {
-      "version": "0.11.64",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.11.64.tgz",
-      "integrity": "sha512-S6pLRaDKOyOFPfry7Km+Bgwr087gwHI4n3fp8NLGHtL75mLnOdeGvSEVW5LXJEWc5EyYgngM2CeS7xNHz+vjHg==",
-      "dependencies": {
-        "@ethersproject/address": "^5.6.0",
-        "@keplr-wallet/common": "0.11.64",
-        "@keplr-wallet/crypto": "0.11.64",
-        "@keplr-wallet/proto-types": "0.11.64",
-        "@keplr-wallet/types": "0.11.64",
-        "@keplr-wallet/unit": "0.11.64",
-        "axios": "^0.27.2",
-        "bech32": "^1.1.4",
-        "buffer": "^6.0.3",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
-      }
-    },
-    "node_modules/@chain-registry/types/node_modules/@keplr-wallet/proto-types": {
-      "version": "0.11.64",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.11.64.tgz",
-      "integrity": "sha512-3oxfD1+zHPPuyKz41wt5A/gVhf2FQbA/L2u/4TxnmnITkY3IENirvMDrZUDJF0pWyGgZuXjhoVVFN2hMWI++PQ==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
-      }
-    },
-    "node_modules/@chain-registry/types/node_modules/@keplr-wallet/types": {
-      "version": "0.11.64",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.64.tgz",
-      "integrity": "sha512-GgzeLDHHfZFyne3O7UIfFHj/uYqVbxAZI31RbBwt460OBbvwQzjrlZwvJW3vieWRAgxKSITjzEDBl2WneFTQdQ==",
-      "dependencies": {
-        "axios": "^0.27.2",
-        "long": "^4.0.0"
-      }
-    },
-    "node_modules/@chain-registry/types/node_modules/@keplr-wallet/unit": {
-      "version": "0.11.64",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.11.64.tgz",
-      "integrity": "sha512-BKTaDYI17QgEcBBCP5ZqsHsfNH29P6VMRxjR4nOXcJfhsuwvdJxa/p88VwQYbpVBw0oXcDOwudNiu7Bgf8w6QQ==",
-      "dependencies": {
-        "@keplr-wallet/types": "0.11.64",
-        "big-integer": "^1.6.48",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@chain-registry/types/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@chain-registry/utils": {
@@ -1402,14 +1218,14 @@
       }
     },
     "node_modules/@cosmjs/amino": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.1.tgz",
-      "integrity": "sha512-kkB9IAkNEUFtjp/uwHv95TgM8VGJ4VWfZwrTyLNqBDD1EpSX2dsNrmUe7k8OMPzKlZUFcKmD4iA0qGvIwzjbGA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
+      "integrity": "sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1"
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3"
       }
     },
     "node_modules/@cosmjs/cosmwasm-stargate": {
@@ -1440,13 +1256,13 @@
       }
     },
     "node_modules/@cosmjs/crypto": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.1.tgz",
-      "integrity": "sha512-4R/SqdzdVzd4E5dpyEh1IKm5GbTqwDogutyIyyb1bcOXiX/x3CrvPI9Tb4WSIMDLvlb5TVzu2YnUV51Q1+6mMA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
+      "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
       "dependencies": {
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
@@ -1454,9 +1270,9 @@
       }
     },
     "node_modules/@cosmjs/encoding": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.1.tgz",
-      "integrity": "sha512-IuxP6ewwX6vg9sUJ8ocJD92pkerI4lyG8J5ynAM3NaX3q+n+uMoPRSQXNeL9bnlrv01FF1kIm8if/f5F7ZPtkA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
+      "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -1464,11 +1280,19 @@
       }
     },
     "node_modules/@cosmjs/json-rpc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.1.tgz",
-      "integrity": "sha512-gIkCj2mUDHAxvmJnHtybXtMLZDeXrkDZlujjzhvJlWsIuj1kpZbKtYqh+eNlfwhMkMMAlQa/y4422jDmizW+ng==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.1.tgz",
+      "integrity": "sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==",
       "dependencies": {
-        "@cosmjs/stream": "^0.31.1",
+        "@cosmjs/stream": "^0.30.1",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/json-rpc/node_modules/@cosmjs/stream": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.1.tgz",
+      "integrity": "sha512-Fg0pWz1zXQdoxQZpdHRMGvUH5RqS6tPv+j9Eh7Q953UjMlrwZVo0YFLC8OTf/HKVf10E4i0u6aM8D69Q6cNkgQ==",
+      "dependencies": {
         "xstream": "^11.14.0"
       }
     },
@@ -1487,23 +1311,23 @@
       }
     },
     "node_modules/@cosmjs/math": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.1.tgz",
-      "integrity": "sha512-kiuHV6m6DSB8/4UV1qpFhlc4ul8SgLXTGRlYkYiIIP4l0YNeJ+OpPYaOlEgx4Unk2mW3/O2FWYj7Jc93+BWXng==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
+      "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
     "node_modules/@cosmjs/proto-signing": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.1.tgz",
-      "integrity": "sha512-hipbBVrssPu+jnmRzQRP5hhS/mbz2nU7RvxG/B1ZcdNhr1AtZC5DN09OTUoEpMSRgyQvScXmk/NTbyf+xmCgYg==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.3.tgz",
+      "integrity": "sha512-24+10/cGl6lLS4VCrGTCJeDRPQTn1K5JfknzXzDIHOx8THR31JxA7/HV5eWGHqWgAbudA7ccdSvEK08lEHHtLA==",
       "dependencies": {
-        "@cosmjs/amino": "^0.31.1",
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/amino": "^0.31.3",
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "cosmjs-types": "^0.8.0",
         "long": "^4.0.0"
       }
@@ -1518,29 +1342,29 @@
       }
     },
     "node_modules/@cosmjs/socket": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.1.tgz",
-      "integrity": "sha512-XTtEr+x3WGbqkzoGX0sCkwVqf5n+bBqDwqNgb+DWaBABQxHVRuuainrTVp0Yc91D3Iy2twLQzeBA9OrRxDSerw==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.3.tgz",
+      "integrity": "sha512-aqrDGGi7os/hsz5p++avI4L0ZushJ+ItnzbqA7C6hamFSCJwgOkXaOUs+K9hXZdX4rhY7rXO4PH9IH8q09JkTw==",
       "dependencies": {
-        "@cosmjs/stream": "^0.31.1",
+        "@cosmjs/stream": "^0.31.3",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/stargate": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.1.tgz",
-      "integrity": "sha512-TqOJZYOH5W3sZIjR6949GfjhGXO3kSHQ3/KmE+SuKyMMmQ5fFZ45beawiRtVF0/CJg5RyPFyFGJKhb1Xxv3Lcg==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.3.tgz",
+      "integrity": "sha512-53NxnzmB9FfXpG4KjOUAYAvWLYKdEmZKsutcat/u2BrDXNZ7BN8jim/ENcpwXfs9/Og0K24lEIdvA4gsq3JDQw==",
       "dependencies": {
         "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/proto-signing": "^0.31.1",
-        "@cosmjs/stream": "^0.31.1",
-        "@cosmjs/tendermint-rpc": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/amino": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/proto-signing": "^0.31.3",
+        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/tendermint-rpc": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "cosmjs-types": "^0.8.0",
         "long": "^4.0.0",
         "protobufjs": "~6.11.3",
@@ -1557,27 +1381,36 @@
       }
     },
     "node_modules/@cosmjs/stream": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.1.tgz",
-      "integrity": "sha512-xsIGD9bpBvYYZASajCyOevh1H5pDdbOWmvb4UwGZ78doGVz3IC3Kb9BZKJHIX2fjq9CMdGVJHmlM+Zp5aM8yZA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.3.tgz",
+      "integrity": "sha512-8keYyI7X0RjsLyVcZuBeNjSv5FA4IHwbFKx7H60NHFXszN8/MvXL6aZbNIvxtcIHHsW7K9QSQos26eoEWlAd+w==",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.1.tgz",
-      "integrity": "sha512-KX+wwi725sSePqIxfMPPOqg+xTETV8BHGOBhRhCZXEl5Fq48UlXXq3/yG1sn7K67ADC0kqHqcCF41Wn1GxNNPA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.3.tgz",
+      "integrity": "sha512-s3TiWkPCW4QceTQjpYqn4xttUJH36mTPqplMl+qyocdqk5+X5mergzExU/pHZRWQ4pbby8bnR7kMvG4OC1aZ8g==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/json-rpc": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/socket": "^0.31.1",
-        "@cosmjs/stream": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/json-rpc": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/socket": "^0.31.3",
+        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/json-rpc": {
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.3.tgz",
+      "integrity": "sha512-7LVYerXjnm69qqYR3uA6LGCrBW2EO5/F7lfJxAmY+iII2C7xO3a0vAjMSt5zBBh29PXrJVS6c2qRP22W1Le2Wg==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.31.3",
         "xstream": "^11.14.0"
       }
     },
@@ -1590,9 +1423,9 @@
       }
     },
     "node_modules/@cosmjs/utils": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.1.tgz",
-      "integrity": "sha512-n4Se1wu4GnKwztQHNFfJvUeWcpvx3o8cWhSbNs9JQShEuB3nv3R5lqFBtDCgHZF/emFQAP+ZjF8bTfCs9UBGhA=="
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
+      "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
     },
     "node_modules/@cosmos-kit/core": {
       "version": "2.6.4",
@@ -2873,9 +2706,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/dmm-proto-ts/node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3110,15 +2943,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/json-rpc": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.1.tgz",
-      "integrity": "sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.30.1",
-        "xstream": "^11.14.0"
-      }
     },
     "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/math": {
       "version": "0.30.1",
@@ -3626,12 +3450,12 @@
       }
     },
     "node_modules/@jest/core/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -3789,9 +3613,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
@@ -3949,9 +3773,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.18",
@@ -3962,79 +3786,57 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
-    },
     "node_modules/@keplr-wallet/common": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.12.16.tgz",
-      "integrity": "sha512-vuPqc3Z3ykqkwHbotf4NwHsz3MeziY/kqqhy1EFkHf7vZaVWd2iwFaHhvkf1qwz9JJwODtlhKWRT89U3d5S6jg==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.16.tgz",
+      "integrity": "sha512-RTbfe8LkPzQQqYntx53dZTuDUgx+W6KRY4g3fIv1c59DS/bp9ZqjYfUDmj3yH0GQk822zqJJwCtjk+qsgvyebg==",
       "dependencies": {
-        "@keplr-wallet/crypto": "0.12.16",
-        "@keplr-wallet/types": "0.12.16",
+        "@keplr-wallet/crypto": "0.11.16",
         "buffer": "^6.0.3",
-        "delay": "^4.4.0",
-        "mobx": "^6.1.7"
-      }
-    },
-    "node_modules/@keplr-wallet/common/node_modules/@keplr-wallet/crypto": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.12.16.tgz",
-      "integrity": "sha512-1Q4j9vfTlAnGqYNm6aqlDVKCg2X0wbFYZt/wTHGmI3x/7Q5qmsngzYMoNi6ss0iGLUy88otIBwBRRqTnUjoOSw==",
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/keccak256": "^5.5.0",
-        "bip32": "^2.0.6",
-        "bip39": "^3.0.3",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "crypto-js": "^4.0.0",
-        "elliptic": "^6.5.3",
-        "sha.js": "^2.4.11"
+        "delay": "^4.4.0"
       }
     },
     "node_modules/@keplr-wallet/cosmos": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.12.16.tgz",
-      "integrity": "sha512-mIhV6YTSa/71yG3SBOP9AmQHxreUetR7WAv6jBnHYXXW1/lilADuV7CtwOOZYs65nOHaiyvjW7ogwqLKr3gJCg==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.11.16.tgz",
+      "integrity": "sha512-Rgch9zw+GKQ2wAKw6I5+J8AAlKHs4MhnkGFfTuqy0e453Ig0+KCHvs+IgMURM9j6E7K0OPQVc4vCvWnQLs6Zbw==",
       "dependencies": {
         "@ethersproject/address": "^5.6.0",
-        "@keplr-wallet/common": "0.12.16",
-        "@keplr-wallet/crypto": "0.12.16",
-        "@keplr-wallet/proto-types": "0.12.16",
-        "@keplr-wallet/simple-fetch": "0.12.16",
-        "@keplr-wallet/types": "0.12.16",
-        "@keplr-wallet/unit": "0.12.16",
+        "@keplr-wallet/common": "0.11.16",
+        "@keplr-wallet/crypto": "0.11.16",
+        "@keplr-wallet/proto-types": "0.11.16",
+        "@keplr-wallet/types": "0.11.16",
+        "@keplr-wallet/unit": "0.11.16",
+        "axios": "^0.27.2",
         "bech32": "^1.1.4",
         "buffer": "^6.0.3",
         "long": "^4.0.0",
         "protobufjs": "^6.11.2"
       }
     },
-    "node_modules/@keplr-wallet/cosmos/node_modules/@keplr-wallet/crypto": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.12.16.tgz",
-      "integrity": "sha512-1Q4j9vfTlAnGqYNm6aqlDVKCg2X0wbFYZt/wTHGmI3x/7Q5qmsngzYMoNi6ss0iGLUy88otIBwBRRqTnUjoOSw==",
-      "peer": true,
+    "node_modules/@keplr-wallet/cosmos/node_modules/@keplr-wallet/types": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.16.tgz",
+      "integrity": "sha512-jkBWj6bcw6BZqPavLms3EcaK6YG4suoTPA9PuO6+eFjj7TomUrzzYdhXyc7Mm0K/KVEz5CjPxjmx7LsPuWYKgg==",
       "dependencies": {
-        "@ethersproject/keccak256": "^5.5.0",
-        "bip32": "^2.0.6",
-        "bip39": "^3.0.3",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "crypto-js": "^4.0.0",
-        "elliptic": "^6.5.3",
-        "sha.js": "^2.4.11"
+        "axios": "^0.27.2",
+        "long": "^4.0.0",
+        "secretjs": "0.17.7"
+      }
+    },
+    "node_modules/@keplr-wallet/cosmos/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@keplr-wallet/crypto": {
-      "version": "0.11.64",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.64.tgz",
-      "integrity": "sha512-DMeGhs+UUBpvefYa/0pF8h8D0lVS1T/eTGNKrn7SIO5CBMp1qfght+k1Se0pHGLr4CAtxFSXTDvYm3mr+ovKhg==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.16.tgz",
+      "integrity": "sha512-th3t05Aq+uQLbhhiqIHbevY3pA4dBKr+vKcUpfdshcc78fI1eGpmzGcQKxlvbectBn4UwamTEANssyplXOGQqg==",
       "dependencies": {
         "@ethersproject/keccak256": "^5.5.0",
         "bip32": "^2.0.6",
@@ -4047,20 +3849,13 @@
       }
     },
     "node_modules/@keplr-wallet/proto-types": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.12.16.tgz",
-      "integrity": "sha512-T0As/BtQ87zvwk0EpXykX6ONgT8h0laUGmsia+qeHyuo1gMrWgoRfFFlGsW7M8wP7eoEvtVNlUQBvwpbtQIjIg==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.11.16.tgz",
+      "integrity": "sha512-0tX7AN1bmlZdpUwqgjQU6MI+p+qBBaWUxHvOrNYtvX0FShw9RihasWdrV6biciQewVd54fChVIGmYKhCLtwPsg==",
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "^6.11.2"
       }
-    },
-    "node_modules/@keplr-wallet/simple-fetch": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.16.tgz",
-      "integrity": "sha512-ma4LCMQgYBnGfJmnCczAukw4OPksufFwHWohvGWzlzDY9luaqyfRLtEJNp9ZqjD4oR1dztUxqNsKmEhaA6r3gA==",
-      "peer": true
     },
     "node_modules/@keplr-wallet/types": {
       "version": "0.12.16",
@@ -4071,14 +3866,32 @@
       }
     },
     "node_modules/@keplr-wallet/unit": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.12.16.tgz",
-      "integrity": "sha512-DudDGE0LHAU988yowNTA0YIDGUpS8SUgtP9bKYxkG8v5xwGZHq1K1PJ4yxT22yEb0t1lOvjOp7j2HQmKzync7w==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.11.16.tgz",
+      "integrity": "sha512-RRVE3oLZq84P4CQONHXDRX+jdqsP9Zar0V9ROAkG4qzitG2glNY/KCVd9SeSOatbGOb/4X88/4pH273TkjtlRA==",
       "dependencies": {
-        "@keplr-wallet/types": "0.12.16",
+        "@keplr-wallet/types": "0.11.16",
         "big-integer": "^1.6.48",
         "utility-types": "^3.10.0"
+      }
+    },
+    "node_modules/@keplr-wallet/unit/node_modules/@keplr-wallet/types": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.16.tgz",
+      "integrity": "sha512-jkBWj6bcw6BZqPavLms3EcaK6YG4suoTPA9PuO6+eFjj7TomUrzzYdhXyc7Mm0K/KVEz5CjPxjmx7LsPuWYKgg==",
+      "dependencies": {
+        "axios": "^0.27.2",
+        "long": "^4.0.0",
+        "secretjs": "0.17.7"
+      }
+    },
+    "node_modules/@keplr-wallet/unit/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@leapwallet/cosmos-snap-provider": {
@@ -4473,25 +4286,6 @@
         "glob": "7.1.7"
       }
     },
-    "node_modules/@next/eslint-plugin-next/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.4.7",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.7.tgz",
@@ -4648,17 +4442,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5425,19 +5208,10 @@
         "events": "^3.3.0"
       }
     },
-    "node_modules/@safe-global/safe-apps-provider/node_modules/@safe-global/safe-apps-sdk": {
+    "node_modules/@safe-global/safe-apps-sdk": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.0.0.tgz",
       "integrity": "sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==",
-      "dependencies": {
-        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
-        "viem": "^1.0.0"
-      }
-    },
-    "node_modules/@safe-global/safe-apps-sdk": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.1.0.tgz",
-      "integrity": "sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==",
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^1.0.0"
@@ -5846,15 +5620,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "dev": true,
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
     "node_modules/@testing-library/dom/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -5955,9 +5720,9 @@
       }
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@toruslabs/openlogin-jrpc": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-4.7.0.tgz",
-      "integrity": "sha512-7Zke2ky9e6HgM6Rs8ByXqrT6s5/l8wn7I11UOUPNPrP9AcYk8n7lDlVu8hniNADDc/IwHZGS0mAbtpRbWletuQ==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-4.7.2.tgz",
+      "integrity": "sha512-9Eb0cPc0lPuS6v2YkQlgzfbRnZ6fLez9Ike5wznoHSFA2/JVu1onwuI56EV1HwswdDrOWPPQEyzI1j9NriZ0ew==",
       "dependencies": {
         "@metamask/rpc-errors": "^5.1.1",
         "@toruslabs/openlogin-utils": "^4.7.0",
@@ -5966,7 +5731,7 @@
         "fast-safe-stringify": "^2.1.1",
         "once": "^1.4.0",
         "pump": "^3.0.0",
-        "readable-stream": "^4.4.1"
+        "readable-stream": "^4.4.2"
       },
       "engines": {
         "node": ">=16.18.1",
@@ -6323,12 +6088,12 @@
       }
     },
     "node_modules/@types/jest/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -6561,15 +6326,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
-      "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
+      "integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.7.0",
-        "@typescript-eslint/types": "6.7.0",
-        "@typescript-eslint/typescript-estree": "6.7.0",
-        "@typescript-eslint/visitor-keys": "6.7.0",
+        "@typescript-eslint/scope-manager": "6.9.0",
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/typescript-estree": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6586,6 +6351,80 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
+      "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
+      "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
+      "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
+      "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.9.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
@@ -8105,11 +7944,11 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dependencies": {
-        "dequal": "^2.0.3"
+        "deep-equal": "^2.0.5"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -8304,9 +8143,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -8864,14 +8703,6 @@
       "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/call-bind": {
@@ -9642,7 +9473,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
       "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
-      "dev": true,
       "dependencies": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
@@ -9718,9 +9548,9 @@
       }
     },
     "node_modules/default-browser/node_modules/execa": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-      "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -10309,7 +10139,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -10874,11 +10703,11 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11338,9 +11167,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.6.5.tgz",
-      "integrity": "sha512-Tc3HXzI0UJ9EhPp6E0fntkgMIA2//rhcB0UsmiRMCR+Bii5iu0RjtwJV55IhlLJ4K39pd0ku+eE4WRgqrLLW2Q==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.0.tgz",
+      "integrity": "sha512-zrFbmQRlraM+cU5mE4CZTLBurZTs2gdp2ld0nG/f3ecBK+x6lZ69KSxBqZ4NjclxwfTxl5LeNufcBbMsTdY53Q==",
       "funding": [
         {
           "type": "individual",
@@ -11352,9 +11181,9 @@
         }
       ],
       "dependencies": {
-        "@adraffy/ens-normalize": "1.9.2",
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.7.1",
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
         "@types/node": "18.15.13",
         "aes-js": "4.0.0-beta.5",
         "tslib": "2.4.0",
@@ -11364,16 +11193,27 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ethers/node_modules/@noble/hashes": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/ethers/node_modules/@types/node": {
       "version": "18.15.13",
@@ -11932,9 +11772,12 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -12047,14 +11890,14 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -12082,9 +11925,9 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "node_modules/globals": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -12332,6 +12175,17 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/headers-polyfill": {
@@ -12777,11 +12631,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12904,7 +12758,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
       "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13036,7 +12889,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
       "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13126,7 +12978,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
       "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -13146,7 +12997,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
       "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -13421,12 +13271,12 @@
       }
     },
     "node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -13605,12 +13455,12 @@
       }
     },
     "node_modules/jest-config/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -13668,12 +13518,12 @@
       }
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -13744,12 +13594,12 @@
       }
     },
     "node_modules/jest-each/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -13879,12 +13729,12 @@
       }
     },
     "node_modules/jest-leak-detector/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -13930,12 +13780,12 @@
       }
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -13998,12 +13848,12 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -14264,12 +14114,12 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -14374,12 +14224,12 @@
       }
     },
     "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.6.0",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -14629,9 +14479,9 @@
       }
     },
     "node_modules/jsdom/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -15195,9 +15045,9 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15415,16 +15265,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/mobx": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.10.0.tgz",
-      "integrity": "sha512-WMbVpCMFtolbB8swQ5E2YRrU+Yu8iLozCVx3CdGjbBKlP7dFiCSuiG06uea3JCFN5DnvtAX7+G5Bp82e2xu0ww==",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
       }
     },
     "node_modules/motion": {
@@ -16405,14 +16245,17 @@
       }
     },
     "node_modules/pino-pretty/node_modules/on-exit-leak-free": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
-      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
-      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -16434,9 +16277,9 @@
       }
     },
     "node_modules/pino-pretty/node_modules/sonic-boom": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
-      "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.7.0.tgz",
+      "integrity": "sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -17295,11 +17138,11 @@
       "dev": true
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -17448,9 +17291,9 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -18032,7 +17875,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
       "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dev": true,
       "dependencies": {
         "internal-slot": "^1.0.4"
       },
@@ -18859,9 +18701,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -19400,9 +19242,9 @@
       }
     },
     "node_modules/viem/node_modules/@types/ws": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-      "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -19617,7 +19459,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
       "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dev": true,
       "dependencies": {
         "is-map": "^2.0.1",
         "is-set": "^2.0.1",
@@ -19886,9 +19727,9 @@
       "dev": true
     },
     "@adraffy/ens-normalize": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
-      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
     },
     "@alloc/quick-lru": {
       "version": "5.2.0",
@@ -19954,25 +19795,6 @@
         "ws": "^8.13.0"
       },
       "dependencies": {
-        "@cosmjs/json-rpc": {
-          "version": "0.30.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.1.tgz",
-          "integrity": "sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==",
-          "requires": {
-            "@cosmjs/stream": "^0.30.1",
-            "xstream": "^11.14.0"
-          },
-          "dependencies": {
-            "@cosmjs/stream": {
-              "version": "0.30.1",
-              "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.1.tgz",
-              "integrity": "sha512-Fg0pWz1zXQdoxQZpdHRMGvUH5RqS6tPv+j9Eh7Q953UjMlrwZVo0YFLC8OTf/HKVf10E4i0u6aM8D69Q6cNkgQ==",
-              "requires": {
-                "xstream": "^11.14.0"
-              }
-            }
-          }
-        },
         "@cosmjs/stargate": {
           "version": "0.31.0-alpha.1",
           "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.0-alpha.1.tgz",
@@ -20473,11 +20295,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
       }
     },
     "@babel/template": {
@@ -20540,17 +20369,24 @@
       "requires": {}
     },
     "@buf/cosmos_cosmos-sdk.bufbuild_es": {
-      "version": "1.0.0-20230719110346-aa25660f4ff7.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.0.0-20230719110346-aa25660f4ff7.1.tgz",
+      "version": "1.0.0-20230316080531-954f7b05f384.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.0.0-20230316080531-954f7b05f384.1.tgz",
       "requires": {
         "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20230509103710-5e5b9fdd0180.1",
-        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20230502210827-cc916c318597.1"
+        "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
+        "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221214150216-75b4300737fb.1"
+      },
+      "dependencies": {
+        "@buf/googleapis_googleapis.bufbuild_es": {
+          "version": "1.0.0-20221214150216-75b4300737fb.1",
+          "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20221214150216-75b4300737fb.1.tgz",
+          "requires": {}
+        }
       }
     },
     "@buf/cosmos_gogo-proto.bufbuild_es": {
-      "version": "1.0.0-20230509103710-5e5b9fdd0180.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.0.0-20230509103710-5e5b9fdd0180.1.tgz",
+      "version": "1.0.0-20221020125208-34d970b699f8.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.0.0-20221020125208-34d970b699f8.1.tgz",
       "requires": {}
     },
     "@buf/cosmos_ibc.bufbuild_es": {
@@ -20562,34 +20398,6 @@
         "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
         "@buf/cosmos_ics23.bufbuild_es": "1.0.0-20221207100654-55085f7c710a.1",
         "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20220908150232-8d7204855ec1.1"
-      },
-      "dependencies": {
-        "@buf/cosmos_cosmos-sdk.bufbuild_es": {
-          "version": "1.0.0-20230316080531-954f7b05f384.1",
-          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_cosmos-sdk.bufbuild_es/-/cosmos_cosmos-sdk.bufbuild_es-1.0.0-20230316080531-954f7b05f384.1.tgz",
-          "requires": {
-            "@buf/cosmos_cosmos-proto.bufbuild_es": "1.0.0-20211202220400-1935555c206d.1",
-            "@buf/cosmos_gogo-proto.bufbuild_es": "1.0.0-20221020125208-34d970b699f8.1",
-            "@buf/googleapis_googleapis.bufbuild_es": "1.0.0-20221214150216-75b4300737fb.1"
-          },
-          "dependencies": {
-            "@buf/googleapis_googleapis.bufbuild_es": {
-              "version": "1.0.0-20221214150216-75b4300737fb.1",
-              "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20221214150216-75b4300737fb.1.tgz",
-              "requires": {}
-            }
-          }
-        },
-        "@buf/cosmos_gogo-proto.bufbuild_es": {
-          "version": "1.0.0-20221020125208-34d970b699f8.1",
-          "resolved": "https://buf.build/gen/npm/v1/@buf/cosmos_gogo-proto.bufbuild_es/-/cosmos_gogo-proto.bufbuild_es-1.0.0-20221020125208-34d970b699f8.1.tgz",
-          "requires": {}
-        },
-        "@buf/googleapis_googleapis.bufbuild_es": {
-          "version": "1.0.0-20220908150232-8d7204855ec1.1",
-          "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20220908150232-8d7204855ec1.1.tgz",
-          "requires": {}
-        }
       }
     },
     "@buf/cosmos_ics23.bufbuild_es": {
@@ -20634,8 +20442,8 @@
       }
     },
     "@buf/googleapis_googleapis.bufbuild_es": {
-      "version": "1.0.0-20230502210827-cc916c318597.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20230502210827-cc916c318597.1.tgz",
+      "version": "1.0.0-20220908150232-8d7204855ec1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/googleapis_googleapis.bufbuild_es/-/googleapis_googleapis.bufbuild_es-1.0.0-20220908150232-8d7204855ec1.1.tgz",
       "requires": {}
     },
     "@bufbuild/protobuf": {
@@ -20683,87 +20491,6 @@
           "requires": {
             "@babel/runtime": "^7.19.4"
           }
-        },
-        "@keplr-wallet/common": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.16.tgz",
-          "integrity": "sha512-RTbfe8LkPzQQqYntx53dZTuDUgx+W6KRY4g3fIv1c59DS/bp9ZqjYfUDmj3yH0GQk822zqJJwCtjk+qsgvyebg==",
-          "requires": {
-            "@keplr-wallet/crypto": "0.11.16",
-            "buffer": "^6.0.3",
-            "delay": "^4.4.0"
-          }
-        },
-        "@keplr-wallet/cosmos": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.11.16.tgz",
-          "integrity": "sha512-Rgch9zw+GKQ2wAKw6I5+J8AAlKHs4MhnkGFfTuqy0e453Ig0+KCHvs+IgMURM9j6E7K0OPQVc4vCvWnQLs6Zbw==",
-          "requires": {
-            "@ethersproject/address": "^5.6.0",
-            "@keplr-wallet/common": "0.11.16",
-            "@keplr-wallet/crypto": "0.11.16",
-            "@keplr-wallet/proto-types": "0.11.16",
-            "@keplr-wallet/types": "0.11.16",
-            "@keplr-wallet/unit": "0.11.16",
-            "axios": "^0.27.2",
-            "bech32": "^1.1.4",
-            "buffer": "^6.0.3",
-            "long": "^4.0.0",
-            "protobufjs": "^6.11.2"
-          }
-        },
-        "@keplr-wallet/crypto": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.16.tgz",
-          "integrity": "sha512-th3t05Aq+uQLbhhiqIHbevY3pA4dBKr+vKcUpfdshcc78fI1eGpmzGcQKxlvbectBn4UwamTEANssyplXOGQqg==",
-          "requires": {
-            "@ethersproject/keccak256": "^5.5.0",
-            "bip32": "^2.0.6",
-            "bip39": "^3.0.3",
-            "bs58check": "^2.1.2",
-            "buffer": "^6.0.3",
-            "crypto-js": "^4.0.0",
-            "elliptic": "^6.5.3",
-            "sha.js": "^2.4.11"
-          }
-        },
-        "@keplr-wallet/proto-types": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.11.16.tgz",
-          "integrity": "sha512-0tX7AN1bmlZdpUwqgjQU6MI+p+qBBaWUxHvOrNYtvX0FShw9RihasWdrV6biciQewVd54fChVIGmYKhCLtwPsg==",
-          "requires": {
-            "long": "^4.0.0",
-            "protobufjs": "^6.11.2"
-          }
-        },
-        "@keplr-wallet/types": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.16.tgz",
-          "integrity": "sha512-jkBWj6bcw6BZqPavLms3EcaK6YG4suoTPA9PuO6+eFjj7TomUrzzYdhXyc7Mm0K/KVEz5CjPxjmx7LsPuWYKgg==",
-          "requires": {
-            "axios": "^0.27.2",
-            "long": "^4.0.0",
-            "secretjs": "0.17.7"
-          }
-        },
-        "@keplr-wallet/unit": {
-          "version": "0.11.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.11.16.tgz",
-          "integrity": "sha512-RRVE3oLZq84P4CQONHXDRX+jdqsP9Zar0V9ROAkG4qzitG2glNY/KCVd9SeSOatbGOb/4X88/4pH273TkjtlRA==",
-          "requires": {
-            "@keplr-wallet/types": "0.11.16",
-            "big-integer": "^1.6.48",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
         }
       }
     },
@@ -20775,73 +20502,6 @@
         "@babel/runtime": "^7.19.4",
         "@keplr-wallet/cosmos": "^0.11.12",
         "@keplr-wallet/crypto": "^0.11.12"
-      },
-      "dependencies": {
-        "@keplr-wallet/common": {
-          "version": "0.11.64",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.64.tgz",
-          "integrity": "sha512-kEnv6K+TxH+BBwwqUgiTcIXuRLBn6PaZMO4jwJbE1O8C8Qh/2j1QtkMLAMgl3Nj9qQkHgJ/dvA5oIqOIdLVMwg==",
-          "requires": {
-            "@keplr-wallet/crypto": "0.11.64",
-            "buffer": "^6.0.3",
-            "delay": "^4.4.0"
-          }
-        },
-        "@keplr-wallet/cosmos": {
-          "version": "0.11.64",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.11.64.tgz",
-          "integrity": "sha512-S6pLRaDKOyOFPfry7Km+Bgwr087gwHI4n3fp8NLGHtL75mLnOdeGvSEVW5LXJEWc5EyYgngM2CeS7xNHz+vjHg==",
-          "requires": {
-            "@ethersproject/address": "^5.6.0",
-            "@keplr-wallet/common": "0.11.64",
-            "@keplr-wallet/crypto": "0.11.64",
-            "@keplr-wallet/proto-types": "0.11.64",
-            "@keplr-wallet/types": "0.11.64",
-            "@keplr-wallet/unit": "0.11.64",
-            "axios": "^0.27.2",
-            "bech32": "^1.1.4",
-            "buffer": "^6.0.3",
-            "long": "^4.0.0",
-            "protobufjs": "^6.11.2"
-          }
-        },
-        "@keplr-wallet/proto-types": {
-          "version": "0.11.64",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.11.64.tgz",
-          "integrity": "sha512-3oxfD1+zHPPuyKz41wt5A/gVhf2FQbA/L2u/4TxnmnITkY3IENirvMDrZUDJF0pWyGgZuXjhoVVFN2hMWI++PQ==",
-          "requires": {
-            "long": "^4.0.0",
-            "protobufjs": "^6.11.2"
-          }
-        },
-        "@keplr-wallet/types": {
-          "version": "0.11.64",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.64.tgz",
-          "integrity": "sha512-GgzeLDHHfZFyne3O7UIfFHj/uYqVbxAZI31RbBwt460OBbvwQzjrlZwvJW3vieWRAgxKSITjzEDBl2WneFTQdQ==",
-          "requires": {
-            "axios": "^0.27.2",
-            "long": "^4.0.0"
-          }
-        },
-        "@keplr-wallet/unit": {
-          "version": "0.11.64",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.11.64.tgz",
-          "integrity": "sha512-BKTaDYI17QgEcBBCP5ZqsHsfNH29P6VMRxjR4nOXcJfhsuwvdJxa/p88VwQYbpVBw0oXcDOwudNiu7Bgf8w6QQ==",
-          "requires": {
-            "@keplr-wallet/types": "0.11.64",
-            "big-integer": "^1.6.48",
-            "utility-types": "^3.10.0"
-          }
-        },
-        "axios": {
-          "version": "0.27.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-          "requires": {
-            "follow-redirects": "^1.14.9",
-            "form-data": "^4.0.0"
-          }
-        }
       }
     },
     "@chain-registry/utils": {
@@ -20953,14 +20613,14 @@
       }
     },
     "@cosmjs/amino": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.1.tgz",
-      "integrity": "sha512-kkB9IAkNEUFtjp/uwHv95TgM8VGJ4VWfZwrTyLNqBDD1EpSX2dsNrmUe7k8OMPzKlZUFcKmD4iA0qGvIwzjbGA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
+      "integrity": "sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==",
       "requires": {
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1"
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3"
       }
     },
     "@cosmjs/cosmwasm-stargate": {
@@ -20993,13 +20653,13 @@
       }
     },
     "@cosmjs/crypto": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.1.tgz",
-      "integrity": "sha512-4R/SqdzdVzd4E5dpyEh1IKm5GbTqwDogutyIyyb1bcOXiX/x3CrvPI9Tb4WSIMDLvlb5TVzu2YnUV51Q1+6mMA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
+      "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
       "requires": {
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
@@ -21007,9 +20667,9 @@
       }
     },
     "@cosmjs/encoding": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.1.tgz",
-      "integrity": "sha512-IuxP6ewwX6vg9sUJ8ocJD92pkerI4lyG8J5ynAM3NaX3q+n+uMoPRSQXNeL9bnlrv01FF1kIm8if/f5F7ZPtkA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
+      "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
       "requires": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -21017,12 +20677,22 @@
       }
     },
     "@cosmjs/json-rpc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.1.tgz",
-      "integrity": "sha512-gIkCj2mUDHAxvmJnHtybXtMLZDeXrkDZlujjzhvJlWsIuj1kpZbKtYqh+eNlfwhMkMMAlQa/y4422jDmizW+ng==",
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.1.tgz",
+      "integrity": "sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==",
       "requires": {
-        "@cosmjs/stream": "^0.31.1",
+        "@cosmjs/stream": "^0.30.1",
         "xstream": "^11.14.0"
+      },
+      "dependencies": {
+        "@cosmjs/stream": {
+          "version": "0.30.1",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.1.tgz",
+          "integrity": "sha512-Fg0pWz1zXQdoxQZpdHRMGvUH5RqS6tPv+j9Eh7Q953UjMlrwZVo0YFLC8OTf/HKVf10E4i0u6aM8D69Q6cNkgQ==",
+          "requires": {
+            "xstream": "^11.14.0"
+          }
+        }
       }
     },
     "@cosmjs/ledger-amino": {
@@ -21040,23 +20710,23 @@
       }
     },
     "@cosmjs/math": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.1.tgz",
-      "integrity": "sha512-kiuHV6m6DSB8/4UV1qpFhlc4ul8SgLXTGRlYkYiIIP4l0YNeJ+OpPYaOlEgx4Unk2mW3/O2FWYj7Jc93+BWXng==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
+      "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
       "requires": {
         "bn.js": "^5.2.0"
       }
     },
     "@cosmjs/proto-signing": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.1.tgz",
-      "integrity": "sha512-hipbBVrssPu+jnmRzQRP5hhS/mbz2nU7RvxG/B1ZcdNhr1AtZC5DN09OTUoEpMSRgyQvScXmk/NTbyf+xmCgYg==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.3.tgz",
+      "integrity": "sha512-24+10/cGl6lLS4VCrGTCJeDRPQTn1K5JfknzXzDIHOx8THR31JxA7/HV5eWGHqWgAbudA7ccdSvEK08lEHHtLA==",
       "requires": {
-        "@cosmjs/amino": "^0.31.1",
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/amino": "^0.31.3",
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "cosmjs-types": "^0.8.0",
         "long": "^4.0.0"
       },
@@ -21073,29 +20743,29 @@
       }
     },
     "@cosmjs/socket": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.1.tgz",
-      "integrity": "sha512-XTtEr+x3WGbqkzoGX0sCkwVqf5n+bBqDwqNgb+DWaBABQxHVRuuainrTVp0Yc91D3Iy2twLQzeBA9OrRxDSerw==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.3.tgz",
+      "integrity": "sha512-aqrDGGi7os/hsz5p++avI4L0ZushJ+ItnzbqA7C6hamFSCJwgOkXaOUs+K9hXZdX4rhY7rXO4PH9IH8q09JkTw==",
       "requires": {
-        "@cosmjs/stream": "^0.31.1",
+        "@cosmjs/stream": "^0.31.3",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/stargate": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.1.tgz",
-      "integrity": "sha512-TqOJZYOH5W3sZIjR6949GfjhGXO3kSHQ3/KmE+SuKyMMmQ5fFZ45beawiRtVF0/CJg5RyPFyFGJKhb1Xxv3Lcg==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.3.tgz",
+      "integrity": "sha512-53NxnzmB9FfXpG4KjOUAYAvWLYKdEmZKsutcat/u2BrDXNZ7BN8jim/ENcpwXfs9/Og0K24lEIdvA4gsq3JDQw==",
       "requires": {
         "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/proto-signing": "^0.31.1",
-        "@cosmjs/stream": "^0.31.1",
-        "@cosmjs/tendermint-rpc": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/amino": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/proto-signing": "^0.31.3",
+        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/tendermint-rpc": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "cosmjs-types": "^0.8.0",
         "long": "^4.0.0",
         "protobufjs": "~6.11.3",
@@ -21114,30 +20784,39 @@
       }
     },
     "@cosmjs/stream": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.1.tgz",
-      "integrity": "sha512-xsIGD9bpBvYYZASajCyOevh1H5pDdbOWmvb4UwGZ78doGVz3IC3Kb9BZKJHIX2fjq9CMdGVJHmlM+Zp5aM8yZA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.3.tgz",
+      "integrity": "sha512-8keYyI7X0RjsLyVcZuBeNjSv5FA4IHwbFKx7H60NHFXszN8/MvXL6aZbNIvxtcIHHsW7K9QSQos26eoEWlAd+w==",
       "requires": {
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/tendermint-rpc": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.1.tgz",
-      "integrity": "sha512-KX+wwi725sSePqIxfMPPOqg+xTETV8BHGOBhRhCZXEl5Fq48UlXXq3/yG1sn7K67ADC0kqHqcCF41Wn1GxNNPA==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.3.tgz",
+      "integrity": "sha512-s3TiWkPCW4QceTQjpYqn4xttUJH36mTPqplMl+qyocdqk5+X5mergzExU/pHZRWQ4pbby8bnR7kMvG4OC1aZ8g==",
       "requires": {
-        "@cosmjs/crypto": "^0.31.1",
-        "@cosmjs/encoding": "^0.31.1",
-        "@cosmjs/json-rpc": "^0.31.1",
-        "@cosmjs/math": "^0.31.1",
-        "@cosmjs/socket": "^0.31.1",
-        "@cosmjs/stream": "^0.31.1",
-        "@cosmjs/utils": "^0.31.1",
+        "@cosmjs/crypto": "^0.31.3",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/json-rpc": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/socket": "^0.31.3",
+        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
       },
       "dependencies": {
+        "@cosmjs/json-rpc": {
+          "version": "0.31.3",
+          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.3.tgz",
+          "integrity": "sha512-7LVYerXjnm69qqYR3uA6LGCrBW2EO5/F7lfJxAmY+iII2C7xO3a0vAjMSt5zBBh29PXrJVS6c2qRP22W1Le2Wg==",
+          "requires": {
+            "@cosmjs/stream": "^0.31.3",
+            "xstream": "^11.14.0"
+          }
+        },
         "axios": {
           "version": "0.21.4",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -21149,9 +20828,9 @@
       }
     },
     "@cosmjs/utils": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.1.tgz",
-      "integrity": "sha512-n4Se1wu4GnKwztQHNFfJvUeWcpvx3o8cWhSbNs9JQShEuB3nv3R5lqFBtDCgHZF/emFQAP+ZjF8bTfCs9UBGhA=="
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
+      "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
     },
     "@cosmos-kit/core": {
       "version": "2.6.4",
@@ -22028,9 +21707,9 @@
           "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         },
         "protobufjs": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-          "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+          "version": "7.2.5",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+          "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
           "requires": {
             "@protobufjs/aspromise": "^1.1.2",
             "@protobufjs/base64": "^1.1.2",
@@ -22250,15 +21929,6 @@
               "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
               "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
             }
-          }
-        },
-        "@cosmjs/json-rpc": {
-          "version": "0.30.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.1.tgz",
-          "integrity": "sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==",
-          "requires": {
-            "@cosmjs/stream": "^0.30.1",
-            "xstream": "^11.14.0"
           }
         },
         "@cosmjs/math": {
@@ -22712,12 +22382,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -22840,9 +22510,9 @@
       }
     },
     "@jest/schemas": {
-      "version": "29.6.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.0.tgz",
-      "integrity": "sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.27.8"
@@ -22965,9 +22635,9 @@
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.18",
@@ -22976,87 +22646,61 @@
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
-      },
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": {
-          "version": "1.4.14",
-          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
-        }
       }
     },
     "@keplr-wallet/common": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.12.16.tgz",
-      "integrity": "sha512-vuPqc3Z3ykqkwHbotf4NwHsz3MeziY/kqqhy1EFkHf7vZaVWd2iwFaHhvkf1qwz9JJwODtlhKWRT89U3d5S6jg==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.16.tgz",
+      "integrity": "sha512-RTbfe8LkPzQQqYntx53dZTuDUgx+W6KRY4g3fIv1c59DS/bp9ZqjYfUDmj3yH0GQk822zqJJwCtjk+qsgvyebg==",
       "requires": {
-        "@keplr-wallet/crypto": "0.12.16",
-        "@keplr-wallet/types": "0.12.16",
+        "@keplr-wallet/crypto": "0.11.16",
         "buffer": "^6.0.3",
-        "delay": "^4.4.0",
-        "mobx": "^6.1.7"
-      },
-      "dependencies": {
-        "@keplr-wallet/crypto": {
-          "version": "0.12.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.12.16.tgz",
-          "integrity": "sha512-1Q4j9vfTlAnGqYNm6aqlDVKCg2X0wbFYZt/wTHGmI3x/7Q5qmsngzYMoNi6ss0iGLUy88otIBwBRRqTnUjoOSw==",
-          "peer": true,
-          "requires": {
-            "@ethersproject/keccak256": "^5.5.0",
-            "bip32": "^2.0.6",
-            "bip39": "^3.0.3",
-            "bs58check": "^2.1.2",
-            "buffer": "^6.0.3",
-            "crypto-js": "^4.0.0",
-            "elliptic": "^6.5.3",
-            "sha.js": "^2.4.11"
-          }
-        }
+        "delay": "^4.4.0"
       }
     },
     "@keplr-wallet/cosmos": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.12.16.tgz",
-      "integrity": "sha512-mIhV6YTSa/71yG3SBOP9AmQHxreUetR7WAv6jBnHYXXW1/lilADuV7CtwOOZYs65nOHaiyvjW7ogwqLKr3gJCg==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.11.16.tgz",
+      "integrity": "sha512-Rgch9zw+GKQ2wAKw6I5+J8AAlKHs4MhnkGFfTuqy0e453Ig0+KCHvs+IgMURM9j6E7K0OPQVc4vCvWnQLs6Zbw==",
       "requires": {
         "@ethersproject/address": "^5.6.0",
-        "@keplr-wallet/common": "0.12.16",
-        "@keplr-wallet/crypto": "0.12.16",
-        "@keplr-wallet/proto-types": "0.12.16",
-        "@keplr-wallet/simple-fetch": "0.12.16",
-        "@keplr-wallet/types": "0.12.16",
-        "@keplr-wallet/unit": "0.12.16",
+        "@keplr-wallet/common": "0.11.16",
+        "@keplr-wallet/crypto": "0.11.16",
+        "@keplr-wallet/proto-types": "0.11.16",
+        "@keplr-wallet/types": "0.11.16",
+        "@keplr-wallet/unit": "0.11.16",
+        "axios": "^0.27.2",
         "bech32": "^1.1.4",
         "buffer": "^6.0.3",
         "long": "^4.0.0",
         "protobufjs": "^6.11.2"
       },
       "dependencies": {
-        "@keplr-wallet/crypto": {
-          "version": "0.12.16",
-          "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.12.16.tgz",
-          "integrity": "sha512-1Q4j9vfTlAnGqYNm6aqlDVKCg2X0wbFYZt/wTHGmI3x/7Q5qmsngzYMoNi6ss0iGLUy88otIBwBRRqTnUjoOSw==",
-          "peer": true,
+        "@keplr-wallet/types": {
+          "version": "0.11.16",
+          "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.16.tgz",
+          "integrity": "sha512-jkBWj6bcw6BZqPavLms3EcaK6YG4suoTPA9PuO6+eFjj7TomUrzzYdhXyc7Mm0K/KVEz5CjPxjmx7LsPuWYKgg==",
           "requires": {
-            "@ethersproject/keccak256": "^5.5.0",
-            "bip32": "^2.0.6",
-            "bip39": "^3.0.3",
-            "bs58check": "^2.1.2",
-            "buffer": "^6.0.3",
-            "crypto-js": "^4.0.0",
-            "elliptic": "^6.5.3",
-            "sha.js": "^2.4.11"
+            "axios": "^0.27.2",
+            "long": "^4.0.0",
+            "secretjs": "0.17.7"
+          }
+        },
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
           }
         }
       }
     },
     "@keplr-wallet/crypto": {
-      "version": "0.11.64",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.64.tgz",
-      "integrity": "sha512-DMeGhs+UUBpvefYa/0pF8h8D0lVS1T/eTGNKrn7SIO5CBMp1qfght+k1Se0pHGLr4CAtxFSXTDvYm3mr+ovKhg==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.16.tgz",
+      "integrity": "sha512-th3t05Aq+uQLbhhiqIHbevY3pA4dBKr+vKcUpfdshcc78fI1eGpmzGcQKxlvbectBn4UwamTEANssyplXOGQqg==",
       "requires": {
         "@ethersproject/keccak256": "^5.5.0",
         "bip32": "^2.0.6",
@@ -23069,20 +22713,13 @@
       }
     },
     "@keplr-wallet/proto-types": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.12.16.tgz",
-      "integrity": "sha512-T0As/BtQ87zvwk0EpXykX6ONgT8h0laUGmsia+qeHyuo1gMrWgoRfFFlGsW7M8wP7eoEvtVNlUQBvwpbtQIjIg==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.11.16.tgz",
+      "integrity": "sha512-0tX7AN1bmlZdpUwqgjQU6MI+p+qBBaWUxHvOrNYtvX0FShw9RihasWdrV6biciQewVd54fChVIGmYKhCLtwPsg==",
       "requires": {
         "long": "^4.0.0",
         "protobufjs": "^6.11.2"
       }
-    },
-    "@keplr-wallet/simple-fetch": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.16.tgz",
-      "integrity": "sha512-ma4LCMQgYBnGfJmnCczAukw4OPksufFwHWohvGWzlzDY9luaqyfRLtEJNp9ZqjD4oR1dztUxqNsKmEhaA6r3gA==",
-      "peer": true
     },
     "@keplr-wallet/types": {
       "version": "0.12.16",
@@ -23093,14 +22730,34 @@
       }
     },
     "@keplr-wallet/unit": {
-      "version": "0.12.16",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.12.16.tgz",
-      "integrity": "sha512-DudDGE0LHAU988yowNTA0YIDGUpS8SUgtP9bKYxkG8v5xwGZHq1K1PJ4yxT22yEb0t1lOvjOp7j2HQmKzync7w==",
-      "peer": true,
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.11.16.tgz",
+      "integrity": "sha512-RRVE3oLZq84P4CQONHXDRX+jdqsP9Zar0V9ROAkG4qzitG2glNY/KCVd9SeSOatbGOb/4X88/4pH273TkjtlRA==",
       "requires": {
-        "@keplr-wallet/types": "0.12.16",
+        "@keplr-wallet/types": "0.11.16",
         "big-integer": "^1.6.48",
         "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@keplr-wallet/types": {
+          "version": "0.11.16",
+          "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.16.tgz",
+          "integrity": "sha512-jkBWj6bcw6BZqPavLms3EcaK6YG4suoTPA9PuO6+eFjj7TomUrzzYdhXyc7Mm0K/KVEz5CjPxjmx7LsPuWYKgg==",
+          "requires": {
+            "axios": "^0.27.2",
+            "long": "^4.0.0",
+            "secretjs": "0.17.7"
+          }
+        },
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        }
       }
     },
     "@leapwallet/cosmos-snap-provider": {
@@ -23472,21 +23129,6 @@
       "integrity": "sha512-tVPS/2FKlA3ANCRCYZVT5jdbUKasBU8LG6bYqcNhyORDFTlDYa4cAWQJjZ7msIgLwMQIbL8CAsxrOL8maa/4Lg==",
       "requires": {
         "glob": "7.1.7"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.7",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "@next/swc-darwin-arm64": {
@@ -23555,11 +23197,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
       "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
-    },
-    "@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -23997,23 +23634,12 @@
       "requires": {
         "@safe-global/safe-apps-sdk": "8.0.0",
         "events": "^3.3.0"
-      },
-      "dependencies": {
-        "@safe-global/safe-apps-sdk": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.0.0.tgz",
-          "integrity": "sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==",
-          "requires": {
-            "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
-            "viem": "^1.0.0"
-          }
-        }
       }
     },
     "@safe-global/safe-apps-sdk": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.1.0.tgz",
-      "integrity": "sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.0.0.tgz",
+      "integrity": "sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==",
       "requires": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^1.0.0"
@@ -24361,15 +23987,6 @@
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
-        "aria-query": {
-          "version": "5.1.3",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-          "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-          "dev": true,
-          "requires": {
-            "deep-equal": "^2.0.5"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -24442,9 +24059,9 @@
       },
       "dependencies": {
         "@toruslabs/openlogin-jrpc": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-4.7.0.tgz",
-          "integrity": "sha512-7Zke2ky9e6HgM6Rs8ByXqrT6s5/l8wn7I11UOUPNPrP9AcYk8n7lDlVu8hniNADDc/IwHZGS0mAbtpRbWletuQ==",
+          "version": "4.7.2",
+          "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-4.7.2.tgz",
+          "integrity": "sha512-9Eb0cPc0lPuS6v2YkQlgzfbRnZ6fLez9Ike5wznoHSFA2/JVu1onwuI56EV1HwswdDrOWPPQEyzI1j9NriZ0ew==",
           "requires": {
             "@metamask/rpc-errors": "^5.1.1",
             "@toruslabs/openlogin-utils": "^4.7.0",
@@ -24453,7 +24070,7 @@
             "fast-safe-stringify": "^2.1.1",
             "once": "^1.4.0",
             "pump": "^3.0.0",
-            "readable-stream": "^4.4.1"
+            "readable-stream": "^4.4.2"
           }
         },
         "@toruslabs/openlogin-utils": {
@@ -24753,12 +24370,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           }
@@ -24974,16 +24591,59 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.0.tgz",
-      "integrity": "sha512-jZKYwqNpNm5kzPVP5z1JXAuxjtl2uG+5NpaMocFPTNC2EdYIgbXIPImObOkhbONxtFTTdoZstLZefbaK+wXZng==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
+      "integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "6.7.0",
-        "@typescript-eslint/types": "6.7.0",
-        "@typescript-eslint/typescript-estree": "6.7.0",
-        "@typescript-eslint/visitor-keys": "6.7.0",
+        "@typescript-eslint/scope-manager": "6.9.0",
+        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/typescript-estree": "6.9.0",
+        "@typescript-eslint/visitor-keys": "6.9.0",
         "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
+          "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.9.0",
+            "@typescript-eslint/visitor-keys": "6.9.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
+          "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
+          "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.9.0",
+            "@typescript-eslint/visitor-keys": "6.9.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
+          "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.9.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
@@ -26285,11 +25945,11 @@
       }
     },
     "aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "requires": {
-        "dequal": "^2.0.3"
+        "deep-equal": "^2.0.5"
       }
     },
     "array-buffer-byte-length": {
@@ -26423,9 +26083,9 @@
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g=="
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
+      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -26854,11 +26514,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ=="
-        },
-        "lowercase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-          "integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A=="
         }
       }
     },
@@ -27454,7 +27109,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.2.tgz",
       "integrity": "sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==",
-      "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
@@ -27503,9 +27157,9 @@
       },
       "dependencies": {
         "execa": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
-          "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
           "requires": {
             "cross-spawn": "^7.0.3",
             "get-stream": "^6.0.1",
@@ -27954,7 +27608,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
       "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -28351,11 +28004,11 @@
           }
         },
         "resolve": {
-          "version": "2.0.0-next.4",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+          "version": "2.0.0-next.5",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+          "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
           "requires": {
-            "is-core-module": "^2.9.0",
+            "is-core-module": "^2.13.0",
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
@@ -28726,23 +28379,31 @@
       }
     },
     "ethers": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.6.5.tgz",
-      "integrity": "sha512-Tc3HXzI0UJ9EhPp6E0fntkgMIA2//rhcB0UsmiRMCR+Bii5iu0RjtwJV55IhlLJ4K39pd0ku+eE4WRgqrLLW2Q==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.0.tgz",
+      "integrity": "sha512-zrFbmQRlraM+cU5mE4CZTLBurZTs2gdp2ld0nG/f3ecBK+x6lZ69KSxBqZ4NjclxwfTxl5LeNufcBbMsTdY53Q==",
       "requires": {
-        "@adraffy/ens-normalize": "1.9.2",
-        "@noble/hashes": "1.1.2",
-        "@noble/secp256k1": "1.7.1",
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
         "@types/node": "18.15.13",
         "aes-js": "4.0.0-beta.5",
         "tslib": "2.4.0",
         "ws": "8.5.0"
       },
       "dependencies": {
+        "@noble/curves": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+          "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+          "requires": {
+            "@noble/hashes": "1.3.2"
+          }
+        },
         "@noble/hashes": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
-          "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
         },
         "@types/node": {
           "version": "18.15.13",
@@ -29167,9 +28828,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -29243,14 +28904,14 @@
       }
     },
     "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
+        "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
@@ -29269,9 +28930,9 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
     },
     "globals": {
-      "version": "13.21.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
-      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "requires": {
         "type-fest": "^0.20.2"
       }
@@ -29443,6 +29104,14 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "headers-polyfill": {
@@ -29778,11 +29447,11 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "is-date-object": {
@@ -29852,8 +29521,7 @@
     "is-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "dev": true
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg=="
     },
     "is-nan": {
       "version": "1.3.2",
@@ -29939,8 +29607,7 @@
     "is-set": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "dev": true
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g=="
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -29993,8 +29660,7 @@
     "is-weakmap": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "dev": true
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
     },
     "is-weakref": {
       "version": "1.0.2",
@@ -30008,7 +29674,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
       "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -30210,12 +29875,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -30341,12 +30006,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -30390,12 +30055,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -30449,12 +30114,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -30548,12 +30213,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           }
@@ -30589,12 +30254,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -30643,12 +30308,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -30855,12 +30520,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -30938,12 +30603,12 @@
           }
         },
         "pretty-format": {
-          "version": "29.6.1",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-          "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+          "version": "29.7.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+          "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
           "dev": true,
           "requires": {
-            "@jest/schemas": "^29.6.0",
+            "@jest/schemas": "^29.6.3",
             "ansi-styles": "^5.0.0",
             "react-is": "^18.0.0"
           },
@@ -31150,9 +30815,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
           "dev": true,
           "requires": {}
         }
@@ -31602,9 +31267,9 @@
       }
     },
     "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A=="
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -31771,12 +31436,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-    },
-    "mobx": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.10.0.tgz",
-      "integrity": "sha512-WMbVpCMFtolbB8swQ5E2YRrU+Yu8iLozCVx3CdGjbBKlP7dFiCSuiG06uea3JCFN5DnvtAX7+G5Bp82e2xu0ww==",
-      "peer": true
     },
     "motion": {
       "version": "10.16.2",
@@ -32492,14 +32151,14 @@
       },
       "dependencies": {
         "on-exit-leak-free": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
-          "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+          "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
         },
         "pino-abstract-transport": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
-          "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+          "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
           "requires": {
             "readable-stream": "^4.0.0",
             "split2": "^4.0.0"
@@ -32518,9 +32177,9 @@
           }
         },
         "sonic-boom": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
-          "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.7.0.tgz",
+          "integrity": "sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==",
           "requires": {
             "atomic-sleep": "^1.0.0"
           }
@@ -33104,11 +32763,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -33213,9 +32872,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
           "requires": {}
         }
       }
@@ -33653,7 +33312,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
       "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dev": true,
       "requires": {
         "internal-slot": "^1.0.4"
       }
@@ -34292,9 +33950,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -34660,9 +34318,9 @@
           }
         },
         "@types/ws": {
-          "version": "8.5.6",
-          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-          "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+          "version": "8.5.8",
+          "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+          "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
           "requires": {
             "@types/node": "*"
           }
@@ -34808,7 +34466,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
       "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dev": true,
       "requires": {
         "is-map": "^2.0.1",
         "is-set": "^2.0.1",

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -1,54 +1,73 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const { chains } = require("chain-registry");
-const fs = require("fs/promises");
+var { chains, assets } = require("chain-registry");
+var fs = require("fs/promises");
+
+/** @type {string[]} */ var chainIds = [];
+/** @type {string[]} */ var chainNames = [];
+
+/** @type {Record<string, any>} */ var chainIdToName = {};
+/** @type {Record<string, any>} */ var chainNameToId = {};
+/** @type {Record<string, any>} */ var chainRecord = {};
+/** @type {Record<string, any>} */ var assetsRecord = {};
 
 async function generate() {
-  /** @type {string[]} */
-  const chainIds = [];
+  for (var chain of chains) {
+    delete chain.$schema;
 
-  /** @type {Record<string, any>} */
-  const chainRecord = {};
-
-  for (const chain of chains) {
     if (!chain.chain_id) continue;
+    if (!chain.chain_name) continue;
+
     chainIds.push(chain.chain_id);
+    chainNames.push(chain.chain_name);
+
+    chainIdToName[chain.chain_id] = chain.chain_name;
+    chainIdToName[chain.chain_name] = chain.chain_name;
+
+    chainNameToId[chain.chain_id] = chain.chain_id;
+    chainNameToId[chain.chain_name] = chain.chain_id;
+
     chainRecord[chain.chain_id] = chain;
+  }
+
+  for (var asset of assets) {
+    if (!asset.chain_name) continue;
+    delete asset.$schema;
+    assetsRecord[chainNameToId[asset.chain_name]] = asset.assets;
   }
 
   await fs.mkdir("src/chains/", { recursive: true }).catch(() => {});
 
-  await fs.writeFile(
-    "src/chains/chainIds.js",
-    "module.exports=" + JSON.stringify(chainIds),
-    "utf-8",
-  );
+  var generatedTs = `/* eslint-disable */
+// @ts-nocheck
+import { Asset, Chain } from "@chain-registry/types";
 
-  const chainIdLiteralType = chainIds
-    .map((id) => `"${id}"`)
-    .concat("(string & {})")
-    .join("|");
+export const chainIds = ${JSON.stringify(chainIds)} as const;
+export type ChainId = (typeof chainIds)[number] | (string & {});
 
-  const chainIdsDts = `/* eslint-disable */
-export type ChainId = ${chainIdLiteralType};
-declare const chainIds: ChainId[];
-export default chainIds;
+export const chainNames = ${JSON.stringify(chainNames)} as const;
+export type ChainName = (typeof chainNames)[number] | (string & {});
+
+export type ChainIdOrName = ChainId | ChainName;
+export const chainIdToName: Record<ChainIdOrName, ChainName> = ${JSON.stringify(
+    chainIdToName,
+  )};
+export const chainNameToId: Record<ChainIdOrName, ChainId> = ${JSON.stringify(
+    chainNameToId,
+  )};
+
+export const chainRecord: Record<ChainId, Chain> = ${JSON.stringify(
+    chainRecord,
+  )};
+
+export const assetsRecord: Record<ChainId, Asset[]> = ${JSON.stringify(
+    assetsRecord,
+  )};
 `;
-  await fs.writeFile("src/chains/chainIds.d.ts", chainIdsDts, "utf-8");
 
-  await fs.writeFile(
-    "src/chains/chainRecord.js",
-    "module.exports=" + JSON.stringify(chainRecord),
-    "utf-8",
-  );
-
-  const chainRecordDts = `/* eslint-disable */
-import { Chain } from "@chain-registry/types";
-import { ChainId } from "./chainIds";
-declare const chainRecord: Record<ChainId, Chain>;
-export default chainRecord;
-`;
-  await fs.writeFile("src/chains/chainRecord.d.ts", chainRecordDts, "utf-8");
+  await fs.writeFile("src/chains/generated.ts", generatedTs, {
+    encoding: "utf-8",
+  });
 }
 
 void generate();

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -1,0 +1,24 @@
+/* eslint-disable */
+// @ts-nocheck
+import type { Asset, Chain } from "@chain-registry/types";
+
+import { raise } from "@/utils/assert";
+
+import type { ChainIdOrName } from "./generated";
+import { assetsRecord, chainNameToId, chainRecord } from "./generated";
+
+export const getChain = (idOrName: ChainIdOrName): Chain => {
+  return (
+    chainRecord[chainNameToId[idOrName]] ||
+    raise(`chain '${idOrName}' does not exist in chainRecord`)
+  );
+};
+
+export const getAssets = (idOrName: ChainIdOrName): Asset[] => {
+  return (
+    assetsRecord[chainNameToId[idOrName]] ||
+    raise(`chain '${idOrName}' does not exist in assetsRecord`)
+  );
+};
+
+export * from "./generated";

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,3 @@
+export const raise = (message?: string, opts?: ErrorOptions): never => {
+  throw new Error(message, opts);
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -34,14 +34,13 @@ import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
 import { erc20ABI, PublicClient, usePublicClient } from "wagmi";
 
 import { Chain } from "@/api/queries";
-import { ChainId } from "@/chains/chainIds";
-import chainRecord from "@/chains/chainRecord";
+import { ChainId, getChain } from "@/chains";
 import { multicall3ABI } from "@/constants/abis";
 import { EVM_CHAINS } from "@/constants/constants";
 import { useSkipClient } from "@/solve";
 
 export function getChainByID(chainID: ChainId) {
-  return chainRecord[chainID];
+  return getChain(chainID);
 }
 
 // cache clients to reuse later


### PR DESCRIPTION
## Description

This PR rewrites the chain registry codegen to support two-way resolving chain name to chain id.

## Changes

- `@/chains/chainRecord` and `@/chains/chainIds` is deprecated in favor of index file
- generated sources is now at `src/chains/generated.ts`
- new generated vars: `chainRecord`, `assetsRecord`, `chainIdToName`, `chainNameToId`
- `src/chains/index.ts` is committed and only contain util fns: `getChain` and `getAssets`

## Screenshots

![CleanShot 2023-10-26 at 17 26 38@2x](https://github.com/skip-mev/ibc-dot-fun/assets/8220954/03ad6667-99ea-4b71-905b-673ca23829d6)

## Notes

-
