### PR TITLE
Support Celestia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@radix-ui/react-dialog": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.0.6",
-        "@skip-router/core": "^0.1.0-rc17",
+        "@skip-router/core": "^0.1.0-rc18",
         "@tanstack/react-query": "^4.29.5",
         "@types/node": "20.1.2",
         "@types/react": "18.2.6",
@@ -5684,9 +5684,9 @@
       }
     },
     "node_modules/@skip-router/core": {
-      "version": "0.1.0-rc17",
-      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc17.tgz",
-      "integrity": "sha512-wCO0FTddmuSPOJl4joKEx0S1BS8V3c6O+QZKP8L3YaQ9MJmNt9oCm9BrVrTHlf0SEb7iIOsKlBYU48+iYJdzSA==",
+      "version": "0.1.0-rc18",
+      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc18.tgz",
+      "integrity": "sha512-NszaxWAW3leE6GV+SvGgzCT+mjFds95Rq2Zj+VaurZBqoqZiTH+83CwLf1IO5TD36Z9WUtLhgCN2eIP8E3dpIw==",
       "dependencies": {
         "@axelar-network/axelarjs-sdk": "^0.13.6",
         "@cosmjs/amino": "^0.31.1",
@@ -24665,9 +24665,9 @@
       }
     },
     "@skip-router/core": {
-      "version": "0.1.0-rc17",
-      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc17.tgz",
-      "integrity": "sha512-wCO0FTddmuSPOJl4joKEx0S1BS8V3c6O+QZKP8L3YaQ9MJmNt9oCm9BrVrTHlf0SEb7iIOsKlBYU48+iYJdzSA==",
+      "version": "0.1.0-rc18",
+      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc18.tgz",
+      "integrity": "sha512-NszaxWAW3leE6GV+SvGgzCT+mjFds95Rq2Zj+VaurZBqoqZiTH+83CwLf1IO5TD36Z9WUtLhgCN2eIP8E3dpIw==",
       "requires": {
         "@axelar-network/axelarjs-sdk": "^0.13.6",
         "@cosmjs/amino": "^0.31.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "postinstall": "git submodule init && git submodule update && tsx ./src/scripts/codegen.ts",
+    "postinstall": "git submodule init && git submodule update --remote && tsx ./src/scripts/codegen.ts",
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
@@ -41,7 +41,7 @@
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.0.6",
-    "@skip-router/core": "^0.1.0-rc17",
+    "@skip-router/core": "^0.1.0-rc18",
     "@tanstack/react-query": "^4.29.5",
     "@types/node": "20.1.2",
     "@types/react": "18.2.6",


### PR DESCRIPTION
- Update the chain-registry submodule, which [includes Celestia now](https://github.com/cosmos/chain-registry/tree/master/celestia)
- Update Skip Router to version that also includes Celestia