### PR TITLE
Use V2 lifecycle tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@radix-ui/react-dialog": "^1.0.4",
         "@radix-ui/react-toast": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.0.6",
-        "@skip-router/core": "^0.1.0-rc18",
+        "@skip-router/core": "^0.1.0-rc20",
         "@tanstack/react-query": "^4.29.5",
         "@types/node": "20.1.2",
         "@types/react": "18.2.6",
@@ -5684,9 +5684,9 @@
       }
     },
     "node_modules/@skip-router/core": {
-      "version": "0.1.0-rc18",
-      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc18.tgz",
-      "integrity": "sha512-NszaxWAW3leE6GV+SvGgzCT+mjFds95Rq2Zj+VaurZBqoqZiTH+83CwLf1IO5TD36Z9WUtLhgCN2eIP8E3dpIw==",
+      "version": "0.1.0-rc20",
+      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc20.tgz",
+      "integrity": "sha512-FeApY/Dkb9JbxqNrokiIrQgJE9/YY5G61iMOeixduCOCJapyqqwArFyE1pj4hguDaqKBBbsebVcnSuddOb7fTQ==",
       "dependencies": {
         "@axelar-network/axelarjs-sdk": "^0.13.6",
         "@cosmjs/amino": "^0.31.1",
@@ -24665,9 +24665,9 @@
       }
     },
     "@skip-router/core": {
-      "version": "0.1.0-rc18",
-      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc18.tgz",
-      "integrity": "sha512-NszaxWAW3leE6GV+SvGgzCT+mjFds95Rq2Zj+VaurZBqoqZiTH+83CwLf1IO5TD36Z9WUtLhgCN2eIP8E3dpIw==",
+      "version": "0.1.0-rc20",
+      "resolved": "https://registry.npmjs.org/@skip-router/core/-/core-0.1.0-rc20.tgz",
+      "integrity": "sha512-FeApY/Dkb9JbxqNrokiIrQgJE9/YY5G61iMOeixduCOCJapyqqwArFyE1pj4hguDaqKBBbsebVcnSuddOb7fTQ==",
       "requires": {
         "@axelar-network/axelarjs-sdk": "^0.13.6",
         "@cosmjs/amino": "^0.31.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-toast": "^1.1.4",
     "@radix-ui/react-tooltip": "^1.0.6",
-    "@skip-router/core": "^0.1.0-rc18",
+    "@skip-router/core": "^0.1.0-rc20",
     "@tanstack/react-query": "^4.29.5",
     "@types/node": "20.1.2",
     "@types/react": "18.2.6",

--- a/src/components/ChainSelect/ChainSelectContent.tsx
+++ b/src/components/ChainSelect/ChainSelectContent.tsx
@@ -4,7 +4,7 @@ import { FC, useEffect, useMemo, useRef, useState } from "react";
 import { useWindowSize } from "usehooks-ts";
 
 import { Chain } from "@/api/queries";
-import { chainNameToChainlistURL } from "@/cosmos";
+import { getChainLogo } from "@/cosmos";
 
 interface Props {
   chains: Chain[];
@@ -96,13 +96,7 @@ const ChainSelectContent: FC<Props> = ({ chains, onChange, onClose }) => {
         ) : (
           <div className="h-full overflow-y-auto scrollbar-hide">
             {filteredChains.map((chain) => {
-              let chainLogo = `${chainNameToChainlistURL(
-                chain.chainName,
-              )}/chainImg/_chainImg.svg`;
-              if (chain.chainID === "dydx-mainnet-1") {
-                chainLogo =
-                  "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.png";
-              }
+              const chainLogo = getChainLogo(chain);
               return (
                 <button
                   className="flex text-left w-full items-center gap-4 hover:bg-[#ECD9D9] p-4 rounded-lg transition-colors"

--- a/src/components/ChainSymbol.tsx
+++ b/src/components/ChainSymbol.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 
 import { useChainByID } from "@/api/queries";
 import { ChainIdOrName } from "@/chains";
-import { chainNameToChainlistURL } from "@/cosmos";
+import { getChainLogo } from "@/cosmos";
 
 interface Props {
   chainId: ChainIdOrName;
@@ -14,7 +14,7 @@ export const ChainSymbol = ({ chainId }: Props) => {
 
   const src = useMemo(() => {
     if (!chain) return;
-    return chainNameToChainlistURL(chain.chainName) + "/chainImg/_chainImg.svg";
+    return getChainLogo(chain);
   }, [chain]);
 
   const alt = chain?.prettyName || chain?.chainName || "UNKNOWN";

--- a/src/components/HistoryDialog/index.tsx
+++ b/src/components/HistoryDialog/index.tsx
@@ -15,7 +15,7 @@ export const HistoryDialog = () => {
   const { isReady } = useAssets();
 
   const entries = useMemo(() => {
-    return isReady ? [...Object.entries(history)].reverse() : undefined;
+    return isReady ? Object.entries(history).reverse() : undefined;
   }, [history, isReady]);
 
   if (!isOpen) return null;

--- a/src/components/HistoryDialog/index.tsx
+++ b/src/components/HistoryDialog/index.tsx
@@ -15,14 +15,14 @@ export const HistoryDialog = () => {
   const { isReady } = useAssets();
 
   const entries = useMemo(() => {
-    return isReady ? Object.entries(history) : undefined;
+    return isReady ? [...Object.entries(history)].reverse() : undefined;
   }, [history, isReady]);
 
   if (!isOpen) return null;
 
   return (
     <div className="absolute inset-0 bg-white rounded-3xl z-[999]">
-      <div className="h-full px-4 py-6 overflow-y-auto scrollbar-hide">
+      <div className="flex flex-col h-full px-4 py-6 space-y-6">
         <div className="flex items-center gap-4 pb-2">
           <button
             className="hover:bg-neutral-100 w-8 h-8 rounded-full flex items-center justify-center transition-colors"
@@ -34,21 +34,23 @@ export const HistoryDialog = () => {
           <div className="flex-grow" />
           <HistoryClearButton />
         </div>
-        <HistoryList.Root>
-          {entries && entries.length < 1 && (
-            <span className="text-center text-sm opacity-60 p-2">
-              No recent transactions.
-            </span>
-          )}
-          {entries?.map(([id, data]) => (
-            <HistoryList.Item key={id} id={id} data={data} />
-          ))}
-          {!isReady && (
-            <div className="text-center p-4 opacity-60">
-              Loading transaction history...
-            </div>
-          )}
-        </HistoryList.Root>
+        <div className="h-full overflow-y-auto scrollbar-hide">
+          <HistoryList.Root>
+            {entries && entries.length < 1 && (
+              <span className="text-center text-sm opacity-60 p-2">
+                No recent transactions.
+              </span>
+            )}
+            {entries?.map(([id, data]) => (
+              <HistoryList.Item key={id} id={id} data={data} />
+            ))}
+            {!isReady && (
+              <div className="text-center p-4 opacity-60">
+                Loading transaction history...
+              </div>
+            )}
+          </HistoryList.Root>
+        </div>
       </div>
     </div>
   );

--- a/src/components/RouteDisplay.tsx
+++ b/src/components/RouteDisplay.tsx
@@ -5,7 +5,7 @@ import { FC, Fragment, useMemo, useState } from "react";
 
 import { useChainByID } from "@/api/queries";
 import { useAssets } from "@/context/assets";
-import { chainNameToChainlistURL } from "@/cosmos";
+import { getChainLogo } from "@/cosmos";
 
 export interface SwapVenueConfig {
   name: string;
@@ -86,9 +86,7 @@ const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
             Transfer to{" "}
             <img
               className="inline-block w-4 h-4 -mt-1"
-              src={`${chainNameToChainlistURL(
-                destinationChain.chainName,
-              )}/chainImg/_chainImg.svg`}
+              src={getChainLogo(destinationChain)}
               alt=""
             />{" "}
             <span className="font-semibold text-black">
@@ -116,9 +114,7 @@ const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
           <span className="font-semibold text-black">{asset.symbol}</span> from{" "}
           <img
             className="inline-block w-4 h-4 -mt-1 rounded-full"
-            src={`${chainNameToChainlistURL(
-              sourceChain.chainName,
-            )}/chainImg/_chainImg.svg`}
+            src={getChainLogo(sourceChain)}
             alt=""
             onError={(e) =>
               (e.currentTarget.src = "https://api.dicebear.com/6.x/shapes/svg")
@@ -130,9 +126,7 @@ const TransferStep: FC<{ action: TransferAction }> = ({ action }) => {
           to{" "}
           <img
             className="inline-block w-4 h-4 -mt-1 rounded-full"
-            src={`${chainNameToChainlistURL(
-              destinationChain.chainName,
-            )}/chainImg/_chainImg.svg`}
+            src={getChainLogo(destinationChain)}
             alt=""
             onError={(e) =>
               (e.currentTarget.src = "https://api.dicebear.com/6.x/shapes/svg")

--- a/src/components/TransactionDialog/TransactionDialogContent.tsx
+++ b/src/components/TransactionDialog/TransactionDialogContent.tsx
@@ -11,6 +11,7 @@ import {
   addTxHistory,
   addTxStatus,
   removeTxHistory,
+  successTxHistory,
 } from "@/context/tx-history";
 import Toast from "@/elements/Toast";
 import { useSkipClient } from "@/solve";
@@ -154,6 +155,18 @@ const TransactionDialogContent: FC<Props> = ({
 
           return getOfflineSigner(walletClient, chainID);
         },
+        onTransactionBroadcast: async (txStatus) => {
+          const explorerLink = getExplorerLinkForTx(
+            txStatus.chainID,
+            txStatus.txHash,
+          );
+
+          addTxStatus(historyId, {
+            chainId: txStatus.chainID,
+            txHash: txStatus.txHash,
+            explorerLink: explorerLink || "#",
+          });
+        },
         onTransactionSuccess: async (txStatus) => {
           const explorerLink = getExplorerLinkForTx(
             txStatus.chainID,
@@ -212,6 +225,7 @@ const TransactionDialogContent: FC<Props> = ({
         });
       });
     } finally {
+      successTxHistory(historyId);
       setTransacting(false);
     }
   };

--- a/src/context/tx-history.ts
+++ b/src/context/tx-history.ts
@@ -46,6 +46,20 @@ export const addTxHistory = (input: TxHistoryItemInput) => {
   return [id, newItem] as const;
 };
 
+export const successTxHistory = (id: string) => {
+  useTxHistory.setState((state) => {
+    const current = state[id];
+    if (!current) return state;
+
+    const latest: TxHistoryItem = {
+      ...current,
+      status: "success",
+    };
+
+    return { ...state, [id]: latest };
+  });
+};
+
 export const failTxHistory = (id: string) => {
   useTxHistory.setState((state) => {
     const current = state[id];
@@ -78,8 +92,6 @@ export const addTxStatus = (id: string, txStatus: TxStatus) => {
     const latest: TxHistoryItem = {
       ...current,
       txStatus: newTxStatus,
-      status:
-        newTxStatus.length >= current.route.txsRequired ? "success" : "pending",
     };
 
     return { ...state, [id]: latest };

--- a/src/cosmos/index.ts
+++ b/src/cosmos/index.ts
@@ -1,3 +1,36 @@
+import { Chain } from "@/api/queries";
+
+// chains whose logo provided by the Skip API is not suitable for our UI.
+const chainsToUseChainListLogo = [
+  "mars-1",
+  "migaloo-1",
+  "neutron-1",
+  "pion-1",
+  "noble-1",
+  "osmosis-1",
+  "osmo-test-5",
+  "stride-1",
+];
+
+export function getChainLogo(chain: Chain) {
+  if (chain.chainID === "dydx-mainnet-1") {
+    return "https://raw.githubusercontent.com/cosmos/chain-registry/master/dydx/images/dydx.png";
+  }
+
+  if (chain.chainID === "celestia") {
+    return "https://raw.githubusercontent.com/cosmos/chain-registry/f1d526b2ec1e03f5555b0484ac5942aa12d884ef/celestia/images/celestia.svg";
+  }
+
+  if (chainsToUseChainListLogo.includes(chain.chainID)) {
+    return `${chainNameToChainlistURL(chain.chainName)}/chainImg/_chainImg.svg`;
+  }
+
+  return (
+    chain.logoURI ||
+    `${chainNameToChainlistURL(chain.chainName)}/chainImg/_chainImg.svg`
+  );
+}
+
 export function chainNameToChainlistURL(chainName: string) {
   const idToNameMap: Record<string, string> = {
     kichain: "ki-chain",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,22 @@
 import { useManager } from "@cosmos-kit/react";
+import { useEffect } from "react";
 
 import { SwapWidget } from "@/components/SwapWidget";
 import { WalletModalProvider } from "@/components/WalletModal";
+import {
+  failTxHistory,
+  successTxHistory,
+  useTxHistory,
+} from "@/context/tx-history";
+import { useSkipClient } from "@/solve";
 import { useInterval } from "@/utils/hooks";
 import { queryClient } from "@/utils/query";
 import { getBalancesByChain } from "@/utils/utils";
 
 export default function Home() {
   const { walletRepos } = useManager();
+  const history = useTxHistory();
+  const skipRouter = useSkipClient();
 
   async function prefetchBalances(address: string, chainID: string) {
     try {
@@ -22,6 +31,32 @@ export default function Home() {
     }
   }
 
+  async function updateTransactionHistory() {
+    for (const [id, historyItem] of Object.entries(history)) {
+      if (historyItem.status === "pending") {
+        const firstTx =
+          historyItem.txStatus.length > 0 ? historyItem.txStatus[0] : undefined;
+
+        if (!firstTx) {
+          continue;
+        }
+
+        const status = await skipRouter.transactionStatus({
+          chainID: firstTx.chainId,
+          txHash: firstTx.txHash,
+        });
+
+        if (status.state === "STATE_COMPLETED_SUCCESS") {
+          successTxHistory(id);
+        }
+
+        if (status.state === "STATE_COMPLETED_ERROR") {
+          failTxHistory(id);
+        }
+      }
+    }
+  }
+
   useInterval(() => {
     for (const repo of walletRepos) {
       if (repo.current && repo.current.address) {
@@ -29,6 +64,10 @@ export default function Home() {
       }
     }
   }, 5000);
+
+  useEffect(() => {
+    updateTransactionHistory();
+  });
 
   return (
     <div className="max-w-md mx-auto">


### PR DESCRIPTION
- Bumps `@skip-router/core` to version that uses the V2 lifecycle tracking (PR for skip-router updates coming today or tomorrow)
- Use `onTransactionBroadcast` option on Skip Router to store transaction history upon broadcast (rather than route completion)
- On page load, update pending transactions in history
- Small style updates on tx history