### PR TITLE
Add Terra Astroport Swap Venue Support

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -47,11 +47,11 @@ export interface SwapVenueConfig {
 
 export const SWAP_VENUES: Record<string, SwapVenueConfig> = {
   "neutron-astroport": {
-    name: "Astroport",
+    name: "Neutron Astroport",
     imageURL: "https://avatars.githubusercontent.com/u/87135340",
   },
   "terra-astroport": {
-    name: "Astroport",
+    name: "Terra Astroport",
     imageURL: "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
   },
   "osmosis-poolmanager": {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -50,6 +50,10 @@ export const SWAP_VENUES: Record<string, SwapVenueConfig> = {
     name: "Astroport",
     imageURL: "https://avatars.githubusercontent.com/u/87135340",
   },
+  "terra-astroport": {
+    name: "Astroport",
+    imageURL: "https://raw.githubusercontent.com/cosmos/chain-registry/master/terra2/images/luna.png",
+  },
   "osmosis-poolmanager": {
     name: "Osmosis",
     imageURL:


### PR DESCRIPTION
This PR adds terra astroport to the list of swap venues and changes the naming to incl the network for astroport dexes