### PR TITLE
[SPE-338] Add debug information in the corner when not running in a production environment

### DIFF
--- a/src/components/BuildInfo.tsx
+++ b/src/components/BuildInfo.tsx
@@ -3,15 +3,22 @@ import { ReactNode, useEffect, useState } from "react";
 
 import { API_URL } from "@/constants/api";
 
+const githubUrl = "https://github.com/skip-mev/ibc-dot-fun";
+
 const buildInfo: [string, ReactNode][] = [
   ["node env", process.env.NODE_ENV],
   ["vercel", process.env.VERCEL ? "true" : "false"],
   ["api url", API_URL],
-  ["commit", process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA],
+  [
+    "commit",
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA
+      ? `${githubUrl}/commit/${process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA}`
+      : null,
+  ],
   [
     "pull request",
     process.env.NEXT_PUBLIC_GIT_PULL_REQUEST_ID
-      ? `https://github.com/skip-mev/ibc-dot-fun/pull/${process.env.NEXT_PUBLIC_GIT_PULL_REQUEST_ID}`
+      ? `${githubUrl}/pull/${process.env.NEXT_PUBLIC_GIT_PULL_REQUEST_ID}`
       : null,
   ],
 ];

--- a/src/components/BuildInfo.tsx
+++ b/src/components/BuildInfo.tsx
@@ -1,0 +1,72 @@
+import { clsx } from "clsx";
+import { ReactNode, useEffect, useState } from "react";
+
+import { API_URL } from "@/constants/api";
+
+const buildInfo: [string, ReactNode][] = [
+  ["node env", process.env.NODE_ENV],
+  ["vercel", process.env.VERCEL ? "true" : "false"],
+  ["api url", API_URL],
+  ["commit", process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA],
+  [
+    "pull request",
+    process.env.NEXT_PUBLIC_GIT_PULL_REQUEST_ID
+      ? `https://github.com/skip-mev/ibc-dot-fun/pull/${process.env.NEXT_PUBLIC_GIT_PULL_REQUEST_ID}`
+      : null,
+  ],
+];
+
+export const BuildInfo = () => {
+  const [show, setShow] = useState(
+    () => process.env.NEXT_PUBLIC_VERCEL_ENV !== "production",
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && e.shiftKey) {
+        setShow((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <div
+      className={clsx(
+        "fixed bottom-2 left-2",
+        "bg-white border p-2 rounded shadow-md space-y-2 w-[300px]",
+      )}
+    >
+      <dl>
+        {buildInfo.map(
+          ([k, v], i) =>
+            v && (
+              <div key={i} className="grid grid-cols-3 space-x-2 py-px text-sm">
+                <dd className="col-span-1 truncate">{k}</dd>
+                <dt className="col-span-2 truncate">
+                  {typeof v === "string" && /^https?:\/\//.test(v) ? (
+                    <a
+                      href={v}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-red-600 hover:underline"
+                    >
+                      {v.replace(/^https?:\/\//, "")}
+                    </a>
+                  ) : (
+                    v
+                  )}
+                </dt>
+              </div>
+            ),
+        )}
+      </dl>
+      <div className="text-end text-xs text-neutral-500">
+        shift+esc to toggle
+      </div>
+    </div>
+  );
+};

--- a/src/components/BuildInfo.tsx
+++ b/src/components/BuildInfo.tsx
@@ -7,7 +7,7 @@ const githubUrl = "https://github.com/skip-mev/ibc-dot-fun";
 
 const buildInfo: [string, ReactNode][] = [
   ["node env", process.env.NODE_ENV],
-  ["vercel", process.env.VERCEL ? "true" : "false"],
+  ["vercel env", process.env.NEXT_PUBLIC_VERCEL_ENV ? "true" : "false"],
   ["api url", API_URL],
   [
     "commit",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -18,6 +18,7 @@ import { MetaMaskConnector } from "wagmi/connectors/metaMask";
 import { publicProvider } from "wagmi/providers/public";
 
 import { getAssetLists, getChains } from "@/chains";
+import { BuildInfo } from "@/components/BuildInfo";
 import MainLayout from "@/components/MainLayout";
 import { EVM_CHAINS } from "@/constants/constants";
 import { AssetsProvider } from "@/context/assets";
@@ -90,6 +91,7 @@ export default function App({ Component, pageProps }: AppProps) {
         </QueryClientProvider>
       </main>
       <Analytics />
+      <BuildInfo />
     </>
   );
 }


### PR DESCRIPTION
## Description

This PR adds a conditional build info popup containing relevant data for debugging, such as node env, is vercel, api url, commit ref, and pr link.

https://linear.app/skip/issue/SPE-338/add-debug-information-in-the-corner-when-not-running-in-a-production

## Screenshots

![CleanShot 2023-11-04 at 03 30 12@2x](https://github.com/skip-mev/ibc-dot-fun/assets/8220954/26c66578-0c3a-4c56-8bc4-0ec3eb25be9a)
