### PR TITLE
[SPE-340] Add slippage info below swap out amount

### DIFF
--- a/src/components/AssetInput.tsx
+++ b/src/components/AssetInput.tsx
@@ -9,6 +9,8 @@ import { getFee, useBalancesByChain } from "@/utils/utils";
 
 import AssetSelect from "./AssetSelect";
 import ChainSelect from "./ChainSelect";
+import { useSettingsStore } from "@/context/settings";
+import { disclosure } from "@/context/disclosures";
 
 interface Props {
   amount: string;
@@ -77,6 +79,8 @@ const AssetInput: FC<Props> = ({
     return selectedAssetBalance === "0.0";
   }, [selectedAssetBalance]);
 
+  const { slippage } = useSettingsStore();
+
   return (
     <Fragment>
       <div className="space-y-4 border border-neutral-200 p-4 rounded-lg">
@@ -108,6 +112,14 @@ const AssetInput: FC<Props> = ({
             >
               {amount}
             </p>
+          )}
+          {!onAmountChange && amount !== "0.0" && (
+            <button
+              className="text-neutral-400 text-sm hover:underline"
+              onClick={() => disclosure.open("settingsDialog")}
+            >
+              Max Slippage: {slippage}%
+            </button>
           )}
           {onAmountChange && (
             <input


### PR DESCRIPTION
## Description

This PR adds (max) slippage information on the main swap interface, specifically below the swap out amount.

## Screenshots/Videos

![image](https://github.com/skip-mev/ibc-dot-fun/assets/8220954/8e41bd6e-4add-4de7-a0f9-898c5791a69f)

https://github.com/skip-mev/ibc-dot-fun/assets/8220954/8b6878b2-6ed8-4e44-9854-30a4249dee2f
