### PR TITLE
[SPE-308] show finality times for various evm chains

### DIFF
--- a/src/components/TransactionDialog/TransactionDialogContent.tsx
+++ b/src/components/TransactionDialog/TransactionDialogContent.tsx
@@ -27,6 +27,7 @@ import {
 
 import RouteDisplay from "../RouteDisplay";
 import * as AlertCollapse from "./AlertCollapse";
+import { getFinalityTime } from "@/constants/finality";
 
 interface RouteTransaction {
   status: "INIT" | "PENDING" | "SUCCESS";
@@ -238,6 +239,12 @@ const TransactionDialogContent: FC<Props> = ({
     return chain?.chainType === "evm";
   }, [chains, route.chainIDs]);
 
+  const evmSourceFinalityTime = useMemo(() => {
+    if (!isSourceEvm) return "";
+    const [sourceChainID] = route.chainIDs;
+    return getFinalityTime(sourceChainID);
+  }, [isSourceEvm, route.chainIDs]);
+
   return (
     <Fragment>
       <div className="flex flex-col h-full px-4 py-6 space-y-6 overflow-y-auto scrollbar-hide">
@@ -363,7 +370,7 @@ const TransactionDialogContent: FC<Props> = ({
         {isSourceEvm && (
           <AlertCollapse.Root type="info">
             <AlertCollapse.Trigger>
-              EVM Bridging Finality Time ~30 Minutes
+              EVM Bridging Finality Time {evmSourceFinalityTime}
             </AlertCollapse.Trigger>
             <AlertCollapse.Content>
               <p>

--- a/src/components/TransactionDialog/TransactionDialogContent.tsx
+++ b/src/components/TransactionDialog/TransactionDialogContent.tsx
@@ -370,7 +370,7 @@ const TransactionDialogContent: FC<Props> = ({
         {isSourceEvm && (
           <AlertCollapse.Root type="info">
             <AlertCollapse.Trigger>
-              EVM Bridging Finality Time {evmSourceFinalityTime}
+              EVM bridging finality time is {evmSourceFinalityTime}
             </AlertCollapse.Trigger>
             <AlertCollapse.Content>
               <p>

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -26,7 +26,7 @@ export const EVM_WALLET_LOGOS: Record<string, string> = {
     "https://raw.githubusercontent.com/rainbow-me/rainbowkit/6b460fcba954e155828e03f46228ee88a171a83b/packages/rainbowkit/src/wallets/walletConnectors/injectedWallet/injectedWallet.svg",
 };
 
-const kava = {
+export const kava = {
   id: 2222,
   name: "Kava",
   network: "kava",

--- a/src/constants/finality.ts
+++ b/src/constants/finality.ts
@@ -19,7 +19,7 @@ import { kava } from "./constants";
 const finalityTimeMap: Record<string, string> = {
   [`${ethereum.id}`]: "16 minutes",
   [`${avalanche.id}`]: "3 seconds",
-  [`${polygon.id}`]: "4:42 minutes",
+  [`${polygon.id}`]: "~5 minutes",
   [`${opBNB.id}`]: "46 seconds",
   [`${fantom.id}`]: "3 seconds",
   [`${kava.id}`]: "45 seconds",

--- a/src/constants/finality.ts
+++ b/src/constants/finality.ts
@@ -28,7 +28,7 @@ const finalityTimeMap: Record<string, string> = {
   [`${filecoin.id}`]: "52 minutes",
   [`${moonbeam.id}`]: "25 seconds",
   [`${celo.id}`]: "12 seconds",
-  [`${arbitrum.id}`]: "19:06 minutes",
+  [`${arbitrum.id}`]: "~20 minutes",
   [`${base.id}`]: "24 minutes",
 };
 

--- a/src/constants/finality.ts
+++ b/src/constants/finality.ts
@@ -1,0 +1,38 @@
+import {
+  arbitrum,
+  avalanche,
+  base,
+  celo,
+  fantom,
+  filecoin,
+  linea,
+  mainnet as ethereum,
+  moonbeam,
+  opBNB,
+  optimism,
+  polygon,
+} from "wagmi/chains";
+
+import { kava } from "./constants";
+
+/** @see https://docs.axelar.dev/learn/txduration#common-finality-time-for-interchain-transactions */
+const finalityTimeMap: Record<string, string> = {
+  [`${ethereum.id}`]: "16 minutes",
+  [`${avalanche.id}`]: "3 seconds",
+  [`${polygon.id}`]: "4:42 minutes",
+  [`${opBNB.id}`]: "46 seconds",
+  [`${fantom.id}`]: "3 seconds",
+  [`${kava.id}`]: "45 seconds",
+  [`${optimism.id}`]: "30 minutes",
+  [`${linea.id}`]: "81 minutes",
+  [`${filecoin.id}`]: "52 minutes",
+  [`${moonbeam.id}`]: "25 seconds",
+  [`${celo.id}`]: "12 seconds",
+  [`${arbitrum.id}`]: "19:06 minutes",
+  [`${base.id}`]: "24 minutes",
+};
+
+/** @see https://docs.axelar.dev/learn/txduration#common-finality-time-for-interchain-transactions */
+export const getFinalityTime = (id: string | number) => {
+  return finalityTimeMap[`${id}`] || "~30 minutes";
+};


### PR DESCRIPTION
## Description

This PR updates the finality time display in tx dialog with mappings from the [Axelar documentation](https://docs.axelar.dev/learn/txduration#common-finality-time-for-interchain-transactions).

## Screenshots

| Avalanche | Ethereum | Polygon |
|-|-|-|
|![CleanShot 2023-11-07 at 03 00 32@2x](https://github.com/skip-mev/ibc-dot-fun/assets/8220954/970e4622-02c7-4c75-a19e-3bc0ea40761a)|![CleanShot 2023-11-07 at 02 59 46@2x](https://github.com/skip-mev/ibc-dot-fun/assets/8220954/3ef547ef-7124-42d7-a291-e5c54413b5ed)|![CleanShot 2023-11-07 at 02 59 31@2x](https://github.com/skip-mev/ibc-dot-fun/assets/8220954/dfe7beba-91d3-4026-a0c7-3026c2be315b)|
