### PR TITLE
Add more descriptive errors for routes

### DIFF
--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -41,7 +41,7 @@ export const SwapWidget: FC = () => {
     onSourceAssetChange,
     onDestinationChainChange,
     onDestinationAssetChange,
-    noRouteFound,
+    routeError,
   } = useSwapWidget();
 
   const {
@@ -165,9 +165,9 @@ export const SwapWidget: FC = () => {
               numberOfTransactions={numberOfTransactions}
             />
           )}
-          {noRouteFound && (
+          {routeError !== "" && (
             <div className="bg-red-50 text-red-500 font-medium uppercase text-xs p-3 rounded-md flex items-center w-full text-left">
-              <p className="flex-1">No route found</p>
+              <p className="flex-1">{routeError}</p>
             </div>
           )}
           {destinationChain?.chainID === "dydx-mainnet-1" ? (

--- a/src/components/SwapWidget/useSwapWidget.ts
+++ b/src/components/SwapWidget/useSwapWidget.ts
@@ -38,6 +38,7 @@ export function useSwapWidget() {
     data: routeResponse,
     fetchStatus: routeFetchStatus,
     isError: routeQueryIsError,
+    error: routeQueryError,
   } = useRoute(
     amountInWei,
     formValues.sourceAsset?.denom,
@@ -46,6 +47,40 @@ export function useSwapWidget() {
     formValues.destinationAsset?.chainID,
     true,
   );
+
+  // if (routeQueryError) {
+  //   // get error message
+  //   // @ts-expect-error TODO: fix this
+  //   console.log(routeQueryError.message);
+  // }
+
+  const errorMessage = useMemo(() => {
+    if (!routeQueryError) {
+      return "";
+    }
+
+    if (routeQueryError instanceof Error) {
+      if (
+        routeQueryError.message.includes(
+          "no swap route found after axelar fee of",
+        )
+      ) {
+        return "Amount is too low to cover Axelar fees";
+      }
+
+      if (
+        routeQueryError.message.includes(
+          "evm native destination tokens are currently not supported",
+        )
+      ) {
+        return "EVM native destination tokens are currently not supported";
+      }
+
+      return "Route not found";
+    }
+
+    return String(routeQueryError);
+  }, [routeQueryError]);
 
   const numberOfTransactions = useMemo(() => {
     if (!routeResponse) {
@@ -140,6 +175,7 @@ export function useSwapWidget() {
     onDestinationChainChange,
     onDestinationAssetChange,
     noRouteFound: routeQueryIsError,
+    routeError: errorMessage,
   };
 }
 

--- a/src/components/SwapWidget/useSwapWidget.ts
+++ b/src/components/SwapWidget/useSwapWidget.ts
@@ -48,12 +48,6 @@ export function useSwapWidget() {
     true,
   );
 
-  // if (routeQueryError) {
-  //   // get error message
-  //   // @ts-expect-error TODO: fix this
-  //   console.log(routeQueryError.message);
-  // }
-
   const errorMessage = useMemo(() => {
     if (!routeQueryError) {
       return "";


### PR DESCRIPTION
Properly anticipate possible errors returned by the route endpoint, such as when the swap amount too small and unsupported native evm tokens 