### PR TITLE
[SPE-370] Show finality estimate when destination chain is EVM

### DIFF
--- a/src/components/TransactionDialog/TransactionDialogContent.tsx
+++ b/src/components/TransactionDialog/TransactionDialogContent.tsx
@@ -264,12 +264,6 @@ const TransactionDialogContent: FC<Props> = ({
     return "";
   }, [chains, route.operations]);
 
-  // const evmSourceFinalityTime = useMemo(() => {
-  //   if (!includesEvmChain) return "";
-  //   const [sourceChainID] = route.chainIDs;
-  //   return getFinalityTime(sourceChainID);
-  // }, [includesEvmChain, route.chainIDs]);
-
   if (txComplete) {
     return (
       <TransactionSuccessView


### PR DESCRIPTION
Previously we were only displaying the finality time estimate when the source chain was EVM, now we check both source and destination.