### PR TITLE
Display warning on high price impact

### DIFF
--- a/src/components/AssetInput.tsx
+++ b/src/components/AssetInput.tsx
@@ -96,15 +96,6 @@ const AssetInput: FC<Props> = ({
 
   const { slippage } = useSettingsStore();
 
-  // const reset = useUsdDiffReset();
-  // useEffect(() => {
-  //   const parsed = parseFloat(amount);
-
-  //   // hotfix side effect to prevent negative amounts
-  //   if (parsed < 0) onAmountChange?.("0.0");
-  //   if (parsed == 0) reset();
-  // }, [amount, onAmountChange, reset]);
-
   return (
     <Fragment>
       <div className="space-y-4 border border-neutral-200 p-4 rounded-lg">

--- a/src/components/AssetInput.tsx
+++ b/src/components/AssetInput.tsx
@@ -2,7 +2,7 @@ import { PencilSquareIcon } from "@heroicons/react/20/solid";
 import { BigNumber } from "bignumber.js";
 import { clsx } from "clsx";
 import { ethers } from "ethers";
-import { FC, Fragment, useEffect, useMemo, useState } from "react";
+import { FC, Fragment, useMemo, useState } from "react";
 
 import { Chain } from "@/api/queries";
 import { AssetWithMetadata, useAssets } from "@/context/assets";
@@ -10,16 +10,17 @@ import { disclosure } from "@/context/disclosures";
 import { useSettingsStore } from "@/context/settings";
 import Toast from "@/elements/Toast";
 import { useAccount } from "@/hooks/useAccount";
-import { getFee, useBalancesByChain } from "@/utils/utils";
+import { formatUSD, getFee, useBalancesByChain } from "@/utils/utils";
 
 import AssetSelect from "./AssetSelect";
 import ChainSelect from "./ChainSelect";
 import { ClientOnly } from "./ClientOnly";
 import { SimpleTooltip } from "./SimpleTooltip";
-import { UsdDiff, UsdValue, useUsdDiffReset } from "./UsdValue";
 
 interface Props {
   amount: string;
+  amountUSD?: string;
+  diffPercentage?: number;
   onAmountChange?: (amount: string) => void;
   asset?: AssetWithMetadata;
   onAssetChange?: (asset: AssetWithMetadata) => void;
@@ -33,6 +34,8 @@ interface Props {
 
 const AssetInput: FC<Props> = ({
   amount,
+  amountUSD,
+  diffPercentage = 0,
   onAmountChange,
   asset,
   onAssetChange,
@@ -93,14 +96,14 @@ const AssetInput: FC<Props> = ({
 
   const { slippage } = useSettingsStore();
 
-  const reset = useUsdDiffReset();
-  useEffect(() => {
-    const parsed = parseFloat(amount);
+  // const reset = useUsdDiffReset();
+  // useEffect(() => {
+  //   const parsed = parseFloat(amount);
 
-    // hotfix side effect to prevent negative amounts
-    if (parsed < 0) onAmountChange?.("0.0");
-    if (parsed == 0) reset();
-  }, [amount, onAmountChange, reset]);
+  //   // hotfix side effect to prevent negative amounts
+  //   if (parsed < 0) onAmountChange?.("0.0");
+  //   if (parsed == 0) reset();
+  // }, [amount, onAmountChange, reset]);
 
   return (
     <Fragment>
@@ -188,33 +191,22 @@ const AssetInput: FC<Props> = ({
             }}
           />
           <div className="flex items-center space-x-2 tabular-nums h-8">
-            {asset && parseFloat(amount) > 0 && (
-              <div className="text-neutral-400 text-sm">
-                <UsdValue
-                  error={null}
-                  chainId={asset.originChainID}
-                  denom={asset.originDenom}
-                  coingeckoID={asset.coingeckoID}
-                  value={amount}
-                  context={context}
-                />
-              </div>
-            )}
-            {context === "dest" && (
-              <UsdDiff.Value>
-                {({ isLoading, percentage }) => (
-                  <div
-                    className={clsx(
-                      "text-sm",
-                      isLoading && "hidden",
-                      percentage > 0 ? "text-green-500" : "text-red-500",
-                    )}
-                  >
-                    ({percentage.toFixed(2)}%)
-                  </div>
+            <p className="text-neutral-400 text-sm">
+              {amountUSD ? formatUSD(amountUSD) : null}
+            </p>
+            {amountUSD !== undefined && context === "dest" ? (
+              <p
+                className={clsx(
+                  "text-sm",
+                  diffPercentage >= 0 ? "text-green-500" : "text-red-500",
                 )}
-              </UsdDiff.Value>
-            )}
+              >
+                {new Intl.NumberFormat("en-US", {
+                  style: "percent",
+                  maximumFractionDigits: 2,
+                }).format(diffPercentage)}
+              </p>
+            ) : null}
             <div className="flex-grow" />
             {showBalance && address && selectedAssetBalance && asset && (
               <div className="text-neutral-400 text-sm flex items-center">

--- a/src/components/PriceImpactWarning.tsx
+++ b/src/components/PriceImpactWarning.tsx
@@ -2,9 +2,13 @@ import { useDisclosureKey } from "@/context/disclosures";
 
 interface Props {
   onGoBack: () => void;
+  warningMessage?: string;
 }
 
-export const PriceImpactWarning = ({ onGoBack }: Props) => {
+export const PriceImpactWarning = ({
+  onGoBack,
+  warningMessage = "",
+}: Props) => {
   const [isOpen, control] = useDisclosureKey("priceImpactWarning");
 
   if (!isOpen) return null;
@@ -31,8 +35,8 @@ export const PriceImpactWarning = ({ onGoBack }: Props) => {
             <p className="font-bold text-lg text-center text-red-500 mb-2">
               Price Impact Warning
             </p>
-            <p className="text-center text-lg max-w-72 mx-auto leading-snug text-gray-500">
-              This route has a high price impact. Do you want to continue?
+            <p className="text-center text-lg px-4 leading-snug text-gray-500">
+              {warningMessage} Do you want to continue?
             </p>
           </div>
           <div className="flex items-end gap-2">

--- a/src/components/PriceImpactWarning.tsx
+++ b/src/components/PriceImpactWarning.tsx
@@ -1,0 +1,59 @@
+import { useDisclosureKey } from "@/context/disclosures";
+
+interface Props {
+  onGoBack: () => void;
+}
+
+export const PriceImpactWarning = ({ onGoBack }: Props) => {
+  const [isOpen, control] = useDisclosureKey("priceImpactWarning");
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="absolute inset-0 bg-white rounded-3xl z-[999]">
+      <div className="h-full px-4 py-6 overflow-y-auto scrollbar-hide">
+        <div className="h-full flex flex-col">
+          <div className="flex-1 pt-8">
+            <div className="text-red-400 flex justify-center py-16">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                className="h-24 w-24"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </div>
+            <p className="font-bold text-lg text-center text-red-500 mb-2">
+              Price Impact Warning
+            </p>
+            <p className="text-center text-lg max-w-72 mx-auto leading-snug text-gray-500">
+              This route has a high price impact. Do you want to continue?
+            </p>
+          </div>
+          <div className="flex items-end gap-2">
+            <button
+              className="bg-[#FF486E] hover:bg-[#ed1149] transition-colors text-white font-semibold py-4 rounded-md w-full"
+              onClick={() => control.close()}
+            >
+              Continue
+            </button>
+            <button
+              className="border border-gray-400 text-gray-500 font-semibold py-4 rounded-md w-full transition-colors hover:bg-gray-50"
+              onClick={() => {
+                control.close();
+                onGoBack();
+              }}
+            >
+              Go Back
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/SwapWidget/SwapDetails.tsx
+++ b/src/components/SwapWidget/SwapDetails.tsx
@@ -2,7 +2,7 @@ import { ChevronDownIcon, PencilSquareIcon } from "@heroicons/react/20/solid";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { RouteResponse } from "@skip-router/core";
 import { clsx } from "clsx";
-import { useMemo } from "react";
+import { Fragment, useEffect, useMemo } from "react";
 
 import { disclosure, useDisclosureKey } from "@/context/disclosures";
 import { useSettingsStore } from "@/context/settings";
@@ -15,6 +15,8 @@ import { FormValues } from "./useSwapWidget";
 type Props = FormValues & {
   amountOut: string;
   route: RouteResponse;
+  priceImpactPercent: number;
+  priceImpactThresholdReached: boolean;
 };
 
 export const SwapDetails = ({
@@ -25,6 +27,8 @@ export const SwapDetails = ({
   destinationChain,
   destinationAsset,
   route,
+  priceImpactPercent,
+  priceImpactThresholdReached,
 }: Props) => {
   const [open, control] = useDisclosureKey("swapDetailsCollapsible");
 
@@ -42,6 +46,12 @@ export const SwapDetails = ({
     const { feeAmount } = axelarTransferOperation.axelarTransfer;
     return +feeAmount / Math.pow(10, 18);
   }, [axelarTransferOperation]);
+
+  useEffect(() => {
+    if (priceImpactThresholdReached) {
+      control.open();
+    }
+  }, [control, priceImpactThresholdReached]);
 
   if (!(sourceChain && sourceAsset && destinationChain && destinationAsset)) {
     return null;
@@ -110,6 +120,29 @@ export const SwapDetails = ({
             "[&_dd]:text-end [&_dd]:tabular-nums",
           )}
         >
+          {priceImpactPercent ? (
+            <Fragment>
+              <dt>
+                <span
+                  className={clsx(
+                    priceImpactThresholdReached ? "text-red-500" : undefined,
+                  )}
+                >
+                  Price Impact
+                </span>
+              </dt>
+              <dd
+                className={clsx(
+                  priceImpactThresholdReached ? "text-red-500" : undefined,
+                )}
+              >
+                {new Intl.NumberFormat("en-US", {
+                  style: "percent",
+                  maximumFractionDigits: 2,
+                }).format(priceImpactPercent)}
+              </dd>
+            </Fragment>
+          ) : null}
           <dt>
             Max Slippage{" "}
             <SimpleTooltip label="Click to change max slippage">

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -50,6 +50,7 @@ export const SwapWidget: FC = () => {
     swapPriceImpactPercent,
     priceImpactThresholdReached,
     routeError,
+    routeWarning,
   } = useSwapWidget();
 
   let usdDiffPercent = 0.0;
@@ -269,6 +270,7 @@ export const SwapWidget: FC = () => {
                   priceImpactThresholdReached ||
                   Math.abs(usdDiffPercent * 100) > PRICE_IMPACT_THRESHOLD
                 }
+                routeWarning={routeWarning}
               />
               {insufficientBalance && (
                 <p className="text-center font-semibold text-sm text-red-500">

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -47,8 +47,17 @@ export const SwapWidget: FC = () => {
     onSourceAssetChange,
     onDestinationChainChange,
     onDestinationAssetChange,
+    swapPriceImpactPercent,
+    priceImpactThresholdReached,
     routeError,
   } = useSwapWidget();
+
+  let usdDiffPercent = 0.0;
+  if (route?.usdAmountIn && route?.usdAmountOut) {
+    usdDiffPercent =
+      (parseFloat(route.usdAmountOut) - parseFloat(route.usdAmountIn)) /
+      parseFloat(route.usdAmountIn);
+  }
 
   const {
     address,
@@ -114,6 +123,7 @@ export const SwapWidget: FC = () => {
           <div data-testid="source">
             <AssetInput
               amount={amountIn}
+              amountUSD={route?.usdAmountIn}
               asset={sourceAsset}
               chain={sourceChain}
               chains={chains ?? []}
@@ -174,6 +184,8 @@ export const SwapWidget: FC = () => {
           <div data-testid="destination">
             <AssetInput
               amount={amountOut}
+              amountUSD={route?.usdAmountOut}
+              diffPercentage={usdDiffPercent}
               asset={destinationAsset}
               chain={destinationChain}
               chains={chains ?? []}
@@ -196,6 +208,8 @@ export const SwapWidget: FC = () => {
               destinationChain={destinationChain}
               destinationAsset={destinationAsset}
               route={route}
+              priceImpactPercent={swapPriceImpactPercent ?? 0}
+              priceImpactThresholdReached={priceImpactThresholdReached}
             />
           )}
           {routeLoading && <RouteLoadingBanner />}
@@ -251,6 +265,7 @@ export const SwapWidget: FC = () => {
                 route={route}
                 transactionCount={numberOfTransactions}
                 insufficientBalance={insufficientBalance}
+                priceImpactThresholdReached={priceImpactThresholdReached}
               />
               {insufficientBalance && (
                 <p className="text-center font-semibold text-sm text-red-500">

--- a/src/components/SwapWidget/SwapWidget.tsx
+++ b/src/components/SwapWidget/SwapWidget.tsx
@@ -23,7 +23,7 @@ import TransactionDialog from "../TransactionDialog";
 import { UsdDiff } from "../UsdValue";
 import { useWalletModal, WalletModal } from "../WalletModal";
 import { SwapDetails } from "./SwapDetails";
-import { useSwapWidget } from "./useSwapWidget";
+import { PRICE_IMPACT_THRESHOLD, useSwapWidget } from "./useSwapWidget";
 
 export const SwapWidget: FC = () => {
   const { openWalletModal } = useWalletModal();
@@ -265,7 +265,10 @@ export const SwapWidget: FC = () => {
                 route={route}
                 transactionCount={numberOfTransactions}
                 insufficientBalance={insufficientBalance}
-                priceImpactThresholdReached={priceImpactThresholdReached}
+                shouldShowPriceImpactWarning={
+                  priceImpactThresholdReached ||
+                  Math.abs(usdDiffPercent * 100) > PRICE_IMPACT_THRESHOLD
+                }
               />
               {insufficientBalance && (
                 <p className="text-center font-semibold text-sm text-red-500">

--- a/src/components/SwapWidget/useSwapWidget.ts
+++ b/src/components/SwapWidget/useSwapWidget.ts
@@ -187,12 +187,6 @@ export function useSwapWidget() {
   }, [swapPriceImpactPercent]);
 
   const usdDiffPercent = useMemo(() => {
-    // if (route?.usdAmountIn && route?.usdAmountOut) {
-    // usdDiffPercent =
-    // (parseFloat(route.usdAmountOut) - parseFloat(route.usdAmountIn)) /
-    // parseFloat(route.usdAmountIn);
-    // }
-
     if (!routeResponse) {
       return undefined;
     }
@@ -206,8 +200,6 @@ export function useSwapWidget() {
 
     return (usdAmountOut - usdAmountIn) / usdAmountIn;
   }, [routeResponse]);
-
-  console.log(usdDiffPercent);
 
   const routeWarning = useMemo(() => {
     if (!routeResponse) {

--- a/src/components/SwapWidget/useSwapWidget.ts
+++ b/src/components/SwapWidget/useSwapWidget.ts
@@ -13,6 +13,8 @@ import { useBalancesByChain } from "@/utils/utils";
 
 export const LAST_SOURCE_CHAIN_KEY = "IBC_DOT_FUN_LAST_SOURCE_CHAIN";
 
+export const PRICE_IMPACT_THRESHOLD = 0.01;
+
 export function useSwapWidget() {
   const {
     onSourceChainChange,
@@ -174,6 +176,16 @@ export function useSwapWidget() {
     }
   }, [currentEvmChain, sourceChain, switchNetwork]);
 
+  const swapPriceImpactPercent = useMemo(() => {
+    if (!routeResponse?.swapPriceImpactPercent) return undefined;
+    return parseFloat(routeResponse.swapPriceImpactPercent) / 100;
+  }, [routeResponse]);
+
+  const priceImpactThresholdReached = useMemo(() => {
+    if (!swapPriceImpactPercent) return false;
+    return swapPriceImpactPercent > PRICE_IMPACT_THRESHOLD;
+  }, [swapPriceImpactPercent]);
+
   return {
     amountIn,
     amountOut,
@@ -193,6 +205,8 @@ export function useSwapWidget() {
     onDestinationAssetChange,
     noRouteFound: routeQueryIsError,
     routeError: errorMessage,
+    swapPriceImpactPercent,
+    priceImpactThresholdReached,
   };
 }
 

--- a/src/components/TransactionDialog/index.tsx
+++ b/src/components/TransactionDialog/index.tsx
@@ -1,6 +1,9 @@
 import { RouteResponse } from "@skip-router/core";
-import { FC, Fragment, useState } from "react";
+import { FC, Fragment, useEffect, useState } from "react";
 
+import { useDisclosureKey } from "@/context/disclosures";
+
+import { PriceImpactWarning } from "../PriceImpactWarning";
 import TransactionDialogContent from "./TransactionDialogContent";
 
 export type ActionType = "NONE" | "TRANSFER" | "SWAP";
@@ -10,6 +13,7 @@ interface Props {
   route?: RouteResponse;
   transactionCount: number;
   insufficientBalance?: boolean;
+  priceImpactThresholdReached?: boolean;
 }
 
 const TransactionDialog: FC<Props> = ({
@@ -17,8 +21,34 @@ const TransactionDialog: FC<Props> = ({
   route,
   insufficientBalance,
   transactionCount,
+  priceImpactThresholdReached,
 }) => {
+  const [hasDisplayedWarning, setHasDisplayedWarning] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+
+  const [, control] = useDisclosureKey("priceImpactWarning");
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHasDisplayedWarning(false);
+      return;
+    }
+
+    if (hasDisplayedWarning) {
+      return;
+    }
+
+    if (priceImpactThresholdReached) {
+      control.open();
+      setHasDisplayedWarning(true);
+    }
+  }, [
+    control,
+    setHasDisplayedWarning,
+    isOpen,
+    hasDisplayedWarning,
+    priceImpactThresholdReached,
+  ]);
 
   return (
     <Fragment>
@@ -43,6 +73,7 @@ const TransactionDialog: FC<Props> = ({
           </div>
         )}
       </div>
+      <PriceImpactWarning onGoBack={() => setIsOpen(false)} />
     </Fragment>
   );
 };

--- a/src/components/TransactionDialog/index.tsx
+++ b/src/components/TransactionDialog/index.tsx
@@ -14,6 +14,7 @@ interface Props {
   transactionCount: number;
   insufficientBalance?: boolean;
   shouldShowPriceImpactWarning?: boolean;
+  routeWarning?: string;
 }
 
 const TransactionDialog: FC<Props> = ({
@@ -22,6 +23,7 @@ const TransactionDialog: FC<Props> = ({
   insufficientBalance,
   transactionCount,
   shouldShowPriceImpactWarning,
+  routeWarning,
 }) => {
   const [hasDisplayedWarning, setHasDisplayedWarning] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -73,7 +75,10 @@ const TransactionDialog: FC<Props> = ({
           </div>
         )}
       </div>
-      <PriceImpactWarning onGoBack={() => setIsOpen(false)} />
+      <PriceImpactWarning
+        onGoBack={() => setIsOpen(false)}
+        warningMessage={routeWarning}
+      />
     </Fragment>
   );
 };

--- a/src/components/TransactionDialog/index.tsx
+++ b/src/components/TransactionDialog/index.tsx
@@ -13,7 +13,7 @@ interface Props {
   route?: RouteResponse;
   transactionCount: number;
   insufficientBalance?: boolean;
-  priceImpactThresholdReached?: boolean;
+  shouldShowPriceImpactWarning?: boolean;
 }
 
 const TransactionDialog: FC<Props> = ({
@@ -21,7 +21,7 @@ const TransactionDialog: FC<Props> = ({
   route,
   insufficientBalance,
   transactionCount,
-  priceImpactThresholdReached,
+  shouldShowPriceImpactWarning,
 }) => {
   const [hasDisplayedWarning, setHasDisplayedWarning] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -38,7 +38,7 @@ const TransactionDialog: FC<Props> = ({
       return;
     }
 
-    if (priceImpactThresholdReached) {
+    if (shouldShowPriceImpactWarning) {
       control.open();
       setHasDisplayedWarning(true);
     }
@@ -47,7 +47,7 @@ const TransactionDialog: FC<Props> = ({
     setHasDisplayedWarning,
     isOpen,
     hasDisplayedWarning,
-    priceImpactThresholdReached,
+    shouldShowPriceImpactWarning,
   ]);
 
   return (

--- a/src/context/disclosures.ts
+++ b/src/context/disclosures.ts
@@ -4,6 +4,7 @@ const defaultValues = {
   historyDialog: false,
   settingsDialog: false,
   swapDetailsCollapsible: false,
+  priceImpactWarning: false,
 
   // TODO: port dialogs to new system
   // assetSelect: false,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -439,7 +439,3 @@ export function formatUSD(amount: string | number) {
   const amountNumber = typeof amount === "string" ? parseFloat(amount) : amount;
   return format(amountNumber);
 }
-
-// export {
-//   formatUSD: format,
-// }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -428,3 +428,18 @@ async function getEvmChainBalances(
 
 export const wait = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+const { format } = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 6,
+});
+
+export function formatUSD(amount: string | number) {
+  const amountNumber = typeof amount === "string" ? parseFloat(amount) : amount;
+  return format(amountNumber);
+}
+
+// export {
+//   formatUSD: format,
+// }


### PR DESCRIPTION
Updates ibc.fun to:
- Use USD values from the API
- Display price impact in the `SwapDetails` component
- If price impact is higher than a configurable threshold (I set to 1%, let me know what you'd actually like it to be):
  - Open the SwapDetails accordion to highlight the high price impact
  - Display a warning popup before submitting any transactions 

https://github.com/skip-mev/ibc-dot-fun/assets/91888455/7848c0a0-4b9c-44eb-a506-ec81ce2d7e0f

