### PR TITLE
fix: hide mode wallet-connect on mobile

### DIFF
--- a/src/components/WalletModal/WalletListItem.tsx
+++ b/src/components/WalletModal/WalletListItem.tsx
@@ -1,10 +1,11 @@
-import { useWalletClient as useCosmosWalletClient } from "@cosmos-kit/react";
+import { useWallet, useWalletClient as useCosmosWalletClient } from "@cosmos-kit/react";
 import { ComponentProps, useEffect, useMemo } from "react";
 import toast from "react-hot-toast";
 import { useConnect } from "wagmi";
 import { create } from "zustand";
 
 import { MergedWalletClient } from "@/lib/cosmos-kit";
+import { isMobile } from "@/utils/os";
 
 const useStore = create<Record<string, true>>(() => ({}));
 
@@ -39,15 +40,25 @@ const CosmosWalletListItem = ({
   walletName: string;
 }) => {
   const { client } = useCosmosWalletClient(walletName);
+  const { wallet } = useWallet(walletName);
+
   const walletClient = client as MergedWalletClient | undefined;
+  const isWalletConnect = wallet?.mode === "wallet-connect";
+  const _isMobile = isMobile();
 
   const show = useMemo(() => {
     if (!walletClient) return false;
     if ("snapInstalled" in walletClient) {
       return walletClient.snapInstalled;
     }
+    if (_isMobile) {
+      return isWalletConnect || walletClient;
+    }
+    if (!_isMobile) {
+      return !isWalletConnect;
+    }
     return true;
-  }, [walletClient]);
+  }, [_isMobile, isWalletConnect, walletClient]);
 
   useEffect(() => {
     const unregister = () => {

--- a/src/utils/os.ts
+++ b/src/utils/os.ts
@@ -1,0 +1,21 @@
+export const isMobile = () => {
+  if (typeof window !== "undefined") {
+    return Boolean(
+      window.matchMedia("(pointer:coarse)").matches ||
+        /Android|webOS|iPhone|iPad|iPod|BlackBerry|Opera Mini/u.test(navigator.userAgent),
+    );
+  }
+
+  return false;
+};
+
+export const isAndroid = () => {
+  return isMobile() && navigator.userAgent.toLowerCase().includes("android");
+};
+
+export const isIos = () => {
+  return (
+    isMobile() &&
+    (navigator.userAgent.toLowerCase().includes("iphone") || navigator.userAgent.toLowerCase().includes("ipad"))
+  );
+};


### PR DESCRIPTION
Currently mobile wallets not working because if the wallet mode is `wallet-connect` it needs to `initClient()` and get generate the qr code from `qrUrl` 

https://linear.app/skip/issue/FRE-560/generate-qr-code-for-mobile-wallets