### PR TITLE
set swap assets from url query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@heroicons/react": "^2.1.1",
     "@injectivelabs/sdk-ts": "^1.14.5",
     "@injectivelabs/utils": "^1.14.5",
+    "@interchain-ui/react": "^1.21.18",
     "@keplr-wallet/types": "^0.12.66",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.0.3",

--- a/src/context/assets.tsx
+++ b/src/context/assets.tsx
@@ -10,6 +10,7 @@ interface AssetsContext {
   assets: Record<string, Asset[]>;
   assetsByChainID: (chainID?: string) => Asset[];
   getAsset(denom: string, chainID: string): Asset | undefined;
+  getAssetBySymbol(symbol: string, chainID: string): Asset | undefined;
   getFeeAsset(chainID: string): Promise<Asset | undefined>;
   getNativeAssets(): Asset[];
   isReady: boolean;
@@ -19,6 +20,7 @@ export const AssetsContext = createContext<AssetsContext>({
   assets: {},
   assetsByChainID: () => [],
   getAsset: () => undefined,
+  getAssetBySymbol: () => undefined,
   getFeeAsset: async () => undefined,
   getNativeAssets: () => [],
   isReady: false,
@@ -39,6 +41,15 @@ export function AssetsProvider({ children }: { children: ReactNode }) {
   const getAsset = useCallback(
     (denom: string, chainID: string) => {
       const asset = assets[chainID]?.find((asset) => asset.denom === denom);
+      return asset;
+    },
+    [assets],
+  );
+
+  const getAssetBySymbol = useCallback(
+    (symbol: string, chainID: string) => {
+      const symbolCaseNormalized = symbol.toUpperCase();
+      const asset = assets[chainID]?.find((asset) => asset.symbol?.toUpperCase() === symbolCaseNormalized);
       return asset;
     },
     [assets],
@@ -106,6 +117,7 @@ export function AssetsProvider({ children }: { children: ReactNode }) {
         assets,
         assetsByChainID,
         getAsset,
+        getAssetBySymbol,
         getFeeAsset,
         getNativeAssets,
         isReady,

--- a/src/utils/str.ts
+++ b/src/utils/str.ts
@@ -1,0 +1,13 @@
+/***
+ * Splits a string at the first encountered delimiter, scanning the string
+ * starting from the end.
+ */
+export function splitRight(input: string, delimiter: string): [string, string] | null {
+  const lastIndex = input.lastIndexOf(delimiter);
+  if (lastIndex === -1) {
+    return null; // No underscore found
+  }
+  const firstPart = input.slice(0, lastIndex);
+  const secondPart = input.slice(lastIndex + 1);
+  return [firstPart, secondPart];
+}


### PR DESCRIPTION
Added code that checks URL query params for the source and destination chainID and asset symbols within the `SwapWidget` component. One minor optimization here would be to pass the query string args into the page component from static props, but I left it as-is (using next/router).

It would also make more sense to put this logic outside of the `SwapWidget` itself, but I left it inside the component for now because the onAssetChange callbacks are coming from the useSwapWidget hook, which is itself currently encapsulated within the component.

## Examples
http://localhost:3000?from=juno-1_glto&to=injective-1_inj
http://localhost:3000?from=osmosis-1_juno&to=juno-1_osmo
