### PR TITLE
Bp/fix carbon gas

### DIFF
--- a/src/config/gas.js
+++ b/src/config/gas.js
@@ -6,4 +6,5 @@ const { GasPrice } = require("@cosmjs/stargate");
 exports.CUSTOM_GAS_PRICE_CHAIN_IDS = {
   "dymension_1100-1": GasPrice.fromString("20000000000adym"),
   "noble-1": GasPrice.fromString("0.0uusdc"),
+  "carbon-1": GasPrice.fromString("100swth")
 };

--- a/src/context/assets.tsx
+++ b/src/context/assets.tsx
@@ -54,7 +54,12 @@ export function AssetsProvider({ children }: { children: ReactNode }) {
       if (!feeAsset) {
         const chain = (chains ?? []).find((chain) => chain.chainID === chainID);
         if (!chain) return;
-        [feeAsset] = chain.feeAssets.sort(sortFeeAssets);
+        else if (chainID === "carbon-1") {
+          feeAsset = chain.feeAssets.find((v) => v.denom == "swth")
+          console.log(feeAsset);
+        } else {
+          [feeAsset] = chain.feeAssets.sort(sortFeeAssets);
+        }
       }
       if (!feeAsset) {
         return;


### PR DESCRIPTION
Made two changes to enable transactions to work on carbon network: 

1. Patched the fee asset selection to always select SWTH
2. Increased the gas price of SWTH (from 33.333 to 100) and committed a corresponding change to the chain registry 

